### PR TITLE
런타임과 시뮬레이터 스케줄러 통합

### DIFF
--- a/app/scripts/app_state.py
+++ b/app/scripts/app_state.py
@@ -97,9 +97,6 @@ class MacroState:
     task_list: list[EquippedSkillRef] = field(default_factory=list)
     prepared_skills: set[EquippedSkillRef] = field(default_factory=set)
 
-    # 연계스킬 수행에 필요한 스킬 정보 리스트
-    link_skills_requirements: list[list[EquippedSkillRef]] = field(default_factory=list)
-
     # 매크로 작동 중 사용하는 연계스킬 리스트
     using_link_skills: list[list[EquippedSkillRef]] = field(default_factory=list)
 

--- a/app/scripts/calculator_engine.py
+++ b/app/scripts/calculator_engine.py
@@ -60,9 +60,14 @@ from app.scripts.calculator_models import (
     TargetDanjeonState,
     TargetDistributionState,
 )
-from app.scripts.macro_models import EquippedSkillRef, LinkUseType
+from app.scripts.macro_models import EquippedSkillRef
+from app.scripts.macro_scheduler import (
+    build_auto_link_skill_groups,
+    build_priority_skill_sequence,
+    build_skill_cooltimes_ms,
+    take_next_task,
+)
 from app.scripts.registry.skill_registry import get_builtin_skill_id
-from app.scripts.run_macro import get_prepared_link_skill_indices
 
 if TYPE_CHECKING:
     from app.scripts.macro_models import MacroPreset, SkillUsageSetting
@@ -1924,39 +1929,6 @@ def _normalize_inverse_stat_map(
     return normalized_values
 
 
-def _build_skill_sequence(
-    server_spec: "ServerSpec",
-    preset: "MacroPreset",
-    skills_info: dict[str, "SkillUsageSetting"],
-) -> tuple[EquippedSkillRef, ...]:
-    """우선순위 기준 스킬 순서 구성"""
-
-    # 현재 배치된 스킬만 우선순위 후보로 제한
-    placed_refs: list[EquippedSkillRef] = preset.skills.get_placed_skill_refs(
-        server_spec
-    )
-    skill_sequence: list[EquippedSkillRef] = []
-
-    # 우선순위 숫자 기준 1차 정렬 구성
-    for target_priority in range(1, len(placed_refs) + 1):
-        for skill_ref in placed_refs:
-            skill_id: str = preset.skills.get_placed_skill_id(skill_ref)
-            setting: "SkillUsageSetting" = skills_info[skill_id]
-            if setting.priority != target_priority:
-                continue
-
-            skill_sequence.append(skill_ref)
-
-    # 우선순위 미지정 스킬은 기존 배치 순서 유지
-    for skill_ref in placed_refs:
-        if skill_ref in skill_sequence:
-            continue
-
-        skill_sequence.append(skill_ref)
-
-    return tuple(skill_sequence)
-
-
 def _update_prepared_skills(
     placed_refs: list[EquippedSkillRef],
     skill_cooltime_timers_ms: dict[EquippedSkillRef, int],
@@ -1980,59 +1952,6 @@ def _update_prepared_skills(
         prepared_skills.add(skill_ref)
 
 
-def _build_next_task_list(
-    preset: "MacroPreset",
-    skills_info: dict[str, "SkillUsageSetting"],
-    prepared_skills: set[EquippedSkillRef],
-    link_skill_requirements: list[list[EquippedSkillRef]],
-    auto_link_skills: list[list[EquippedSkillRef]],
-    skill_sequence: tuple[EquippedSkillRef, ...],
-) -> list[EquippedSkillRef]:
-    """현재 시점 기준 실행 가능한 다음 작업 목록 구성"""
-
-    # 자동 연계 완성 여부를 먼저 확인
-    prepared_link_indices: list[int] = get_prepared_link_skill_indices(
-        prepared_skills=prepared_skills,
-        link_skills_requirements=link_skill_requirements,
-    )
-    if prepared_link_indices:
-        target_link_skills: list[EquippedSkillRef] = auto_link_skills[
-            prepared_link_indices[0]
-        ]
-        task_list: list[EquippedSkillRef] = []
-        for skill_ref in target_link_skills:
-            prepared_skills.discard(skill_ref)
-            task_list.append(skill_ref)
-
-        return task_list
-
-    # 자동 연계에 속한 스킬 참조 집합 구성
-    linked_skill_refs: set[EquippedSkillRef] = {
-        skill_ref
-        for requirement_group in link_skill_requirements
-        for skill_ref in requirement_group
-    }
-
-    # 우선순위 순서대로 사용 가능한 첫 스킬 선택
-    for skill_ref in skill_sequence:
-        if skill_ref not in prepared_skills:
-            continue
-
-        skill_id: str = preset.skills.get_placed_skill_id(skill_ref)
-        setting: "SkillUsageSetting" = skills_info[skill_id]
-        in_link: bool = skill_ref in linked_skill_refs
-        can_use: bool = (in_link and setting.use_alone) or (
-            not in_link and setting.use_skill
-        )
-        if not can_use:
-            continue
-
-        prepared_skills.discard(skill_ref)
-        return [skill_ref]
-
-    return []
-
-
 def build_skill_use_sequence(
     server_spec: "ServerSpec",
     preset: "MacroPreset",
@@ -2049,22 +1968,12 @@ def build_skill_use_sequence(
     if not placed_refs:
         return ()
 
-    # 자동 연계 계산에 필요한 배치/설정 맵 구성
+    # 60초 계산은 모든 장착 스킬이 준비된 상태에서 시작
     prepared_skills: set[EquippedSkillRef] = set(placed_refs)
-    skill_ref_map: dict[str, EquippedSkillRef] = preset.skills.get_placed_skill_ref_map(
-        server_spec
+    auto_link_skill_groups: tuple[tuple[EquippedSkillRef, ...], ...] = (
+        build_auto_link_skill_groups(server_spec=server_spec, preset=preset)
     )
-    auto_link_skills: list[list[EquippedSkillRef]] = [
-        [skill_ref_map[skill_id] for skill_id in link_skill.skills]
-        for link_skill in preset.link_skills
-        if link_skill.use_type == LinkUseType.AUTO
-        and all(skill_id in skill_ref_map for skill_id in link_skill.skills)
-    ]
-    link_skill_requirements: list[list[EquippedSkillRef]] = [
-        [skill_ref for skill_ref in link_skill_group]
-        for link_skill_group in auto_link_skills
-    ]
-    skill_sequence: tuple[EquippedSkillRef, ...] = _build_skill_sequence(
+    skill_sequence: tuple[EquippedSkillRef, ...] = build_priority_skill_sequence(
         server_spec=server_spec,
         preset=preset,
         skills_info=skills_info,
@@ -2074,16 +1983,11 @@ def build_skill_use_sequence(
     skill_cooltime_timers_ms: dict[EquippedSkillRef, int] = {
         skill_ref: 0 for skill_ref in placed_refs
     }
-    skill_cooltimes_ms: dict[EquippedSkillRef, int] = {
-        skill_ref: int(
-            server_spec.skill_registry.get(
-                preset.skills.get_placed_skill_id(skill_ref)
-            ).cooltime
-            * (100 - cooltime_reduction)
-            * 10
-        )
-        for skill_ref in placed_refs
-    }
+    skill_cooltimes_ms: dict[EquippedSkillRef, int] = build_skill_cooltimes_ms(
+        server_spec=server_spec,
+        preset=preset,
+        cooltime_reduction=cooltime_reduction,
+    )
 
     # 60초 범위 내 실제 스킬 사용 시점 기록
     task_list: list[EquippedSkillRef] = []
@@ -2098,13 +2002,14 @@ def build_skill_use_sequence(
                 elapsed_time_ms=elapsed_time_ms,
                 prepared_skills=prepared_skills,
             )
-            task_list = _build_next_task_list(
-                preset=preset,
-                skills_info=skills_info,
-                prepared_skills=prepared_skills,
-                link_skill_requirements=link_skill_requirements,
-                auto_link_skills=auto_link_skills,
-                skill_sequence=skill_sequence,
+            task_list = list(
+                take_next_task(
+                    preset=preset,
+                    skills_info=skills_info,
+                    prepared_skills=prepared_skills,
+                    auto_link_skill_groups=auto_link_skill_groups,
+                    skill_sequence=skill_sequence,
+                )
             )
 
         if task_list:
@@ -2113,7 +2018,7 @@ def build_skill_use_sequence(
             used_skills.append(
                 SkillUseEvent(
                     skill_id=skill_id,
-                    time=round(elapsed_time_ms * 0.001, 2),
+                    time=round(elapsed_time_ms * 0.001, 3),
                 )
             )
             skill_cooltime_timers_ms[skill_ref] = elapsed_time_ms

--- a/app/scripts/macro_scheduler.py
+++ b/app/scripts/macro_scheduler.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from app.scripts.macro_models import EquippedSkillRef, LinkUseType, SkillUsageSetting
+
+if TYPE_CHECKING:
+    from app.scripts.macro_models import MacroPreset
+    from app.scripts.registry.server_registry import ServerSpec
+
+
+def build_priority_skill_sequence(
+    server_spec: ServerSpec,
+    preset: MacroPreset,
+    skills_info: dict[str, SkillUsageSetting],
+) -> tuple[EquippedSkillRef, ...]:
+    """우선순위와 배치 순서 기준 스킬 시퀀스 구성"""
+
+    placed_refs: list[EquippedSkillRef] = preset.skills.get_placed_skill_refs(
+        server_spec
+    )
+    skill_sequence: list[EquippedSkillRef] = []
+    for target_priority in range(1, len(placed_refs) + 1):
+        for skill_ref in placed_refs:
+            skill_id: str = preset.skills.get_placed_skill_id(skill_ref)
+            if skills_info[skill_id].priority == target_priority:
+                skill_sequence.append(skill_ref)
+
+    for skill_ref in placed_refs:
+        if skill_ref not in skill_sequence:
+            skill_sequence.append(skill_ref)
+
+    return tuple(skill_sequence)
+
+
+def build_auto_link_skill_groups(
+    server_spec: ServerSpec,
+    preset: MacroPreset,
+) -> tuple[tuple[EquippedSkillRef, ...], ...]:
+    """현재 배치로 완결되는 자동 연계 그룹 구성"""
+
+    skill_ref_map: dict[str, EquippedSkillRef] = (
+        preset.skills.get_placed_skill_ref_map(server_spec)
+    )
+    return tuple(
+        tuple(skill_ref_map[skill_id] for skill_id in link_skill.skills)
+        for link_skill in preset.link_skills
+        if link_skill.use_type == LinkUseType.AUTO
+        and all(skill_id in skill_ref_map for skill_id in link_skill.skills)
+    )
+
+
+def take_next_task(
+    preset: MacroPreset,
+    skills_info: dict[str, SkillUsageSetting],
+    prepared_skills: set[EquippedSkillRef],
+    auto_link_skill_groups: tuple[tuple[EquippedSkillRef, ...], ...],
+    skill_sequence: tuple[EquippedSkillRef, ...],
+) -> tuple[EquippedSkillRef, ...]:
+    """준비 상태에서 다음 자동 연계 또는 일반 스킬을 꺼냄"""
+
+    for link_skill_group in auto_link_skill_groups:
+        if not all(skill_ref in prepared_skills for skill_ref in link_skill_group):
+            continue
+
+        for skill_ref in link_skill_group:
+            prepared_skills.discard(skill_ref)
+        return link_skill_group
+
+    linked_skill_refs: set[EquippedSkillRef] = {
+        skill_ref
+        for link_skill_group in auto_link_skill_groups
+        for skill_ref in link_skill_group
+    }
+    for skill_ref in skill_sequence:
+        if skill_ref not in prepared_skills:
+            continue
+
+        skill_id: str = preset.skills.get_placed_skill_id(skill_ref)
+        setting: SkillUsageSetting = skills_info[skill_id]
+        in_link_skill: bool = skill_ref in linked_skill_refs
+        can_use: bool = (in_link_skill and setting.use_alone) or (
+            not in_link_skill and setting.use_skill
+        )
+        if not can_use:
+            continue
+
+        prepared_skills.discard(skill_ref)
+        return (skill_ref,)
+
+    return ()
+
+
+def build_skill_cooltimes_ms(
+    server_spec: ServerSpec,
+    preset: MacroPreset,
+    cooltime_reduction: float,
+) -> dict[EquippedSkillRef, int]:
+    """쿨타임 감소가 반영된 스킬별 밀리초 쿨타임 구성"""
+
+    return {
+        skill_ref: round(
+            server_spec.skill_registry.get(
+                preset.skills.get_placed_skill_id(skill_ref)
+            ).cooltime
+            * (100 - cooltime_reduction)
+            * 10
+        )
+        for skill_ref in preset.skills.get_placed_skill_refs(server_spec)
+    }

--- a/app/scripts/run_macro.py
+++ b/app/scripts/run_macro.py
@@ -15,8 +15,12 @@ from app.scripts.macro_models import (
     EquippedSkillRef,
     LinkKeyType,
     LinkSkill,
-    LinkUseType,
-    SkillUsageSetting,
+)
+from app.scripts.macro_scheduler import (
+    build_auto_link_skill_groups,
+    build_priority_skill_sequence,
+    build_skill_cooltimes_ms,
+    take_next_task,
 )
 from app.scripts.registry.key_registry import KeyRegistry, KeySpec
 
@@ -49,7 +53,6 @@ class PreviewTaskState:
     task_list: list[EquippedSkillRef]
     skill_sequence: list[EquippedSkillRef]
     using_link_skills: list[list[EquippedSkillRef]]
-    link_skills_requirements: list[list[EquippedSkillRef]]
 
 
 def _register_injected_key_event(key_spec: KeySpec) -> None:
@@ -350,10 +353,7 @@ def checking_kb_thread() -> NoReturn:
 
 
 def running_macro_thread(run_id: int) -> None:
-    """
-    매크로 메인 쓰레드
-    시뮬레이션과 약간의 오차가 있지만 무시할만 함 (나중에 개선 예정)
-    """
+    """매크로 메인 쓰레드"""
 
     global is_input_sequence_running
 
@@ -384,8 +384,9 @@ def running_macro_thread(run_id: int) -> None:
                 attack_hold_seconds: float = _get_attack_hold_seconds()
 
                 if wait_seconds > attack_hold_seconds:
-                    _sleep_while_macro_running(
-                        (wait_seconds - attack_hold_seconds)
+                    _wait_until_while_macro_running(
+                        time.perf_counter()
+                        + (wait_seconds - attack_hold_seconds)
                         * config.macro.SLEEP_COEFFICIENT_UNIT
                     )
                     continue
@@ -413,8 +414,9 @@ def running_macro_thread(run_id: int) -> None:
                 app_state.macro.is_running = False
 
             if not is_used_skill:
-                _sleep_while_macro_running(
-                    wait_seconds * config.macro.SLEEP_COEFFICIENT_UNIT
+                _wait_until_while_macro_running(
+                    time.perf_counter()
+                    + wait_seconds * config.macro.SLEEP_COEFFICIENT_UNIT
                 )
     finally:
         if app_state.macro.run_id == run_id:
@@ -475,10 +477,9 @@ def _pause_attack_for(duration_seconds: float) -> None:
     )
 
 
-def _sleep_while_macro_running(duration_seconds: float) -> None:
-    """매크로 중지 상태를 확인하며 대기"""
+def _wait_until_while_macro_running(end_at: float) -> None:
+    """매크로 중지 상태를 확인하며 목표 시각까지 대기"""
 
-    end_at: float = time.perf_counter() + max(0.0, duration_seconds)
     while app_state.macro.is_running:
         remaining_seconds: float = end_at - time.perf_counter()
         if remaining_seconds <= 0.0:
@@ -529,40 +530,8 @@ def _press_skill_keys(
 
     # 프로그램 주입 스킬 입력 등록
     _press_key_spec(kbd_controller, mouse_controller, skill_key)
+
     return current_line_index
-
-
-def _collect_priority_skill_sequence() -> list[EquippedSkillRef]:
-    """우선순위 기준 스킬 순서 반환"""
-
-    placed_refs: list[EquippedSkillRef] = (
-        app_state.macro.current_preset.skills.get_placed_skill_refs(
-            app_state.macro.current_server
-        )
-    )
-    skill_sequence: list[EquippedSkillRef] = []
-
-    # 현재 하단 슬롯에 실제 배치된 스킬만 우선순위 후보로 제한
-    for target_priority in range(1, len(placed_refs) + 1):
-        for skill_ref in placed_refs:
-            skill_id: str = app_state.macro.current_preset.skills.get_placed_skill_id(
-                skill_ref
-            )
-            setting: SkillUsageSetting = app_state.macro.current_preset.usage_settings[
-                skill_id
-            ]
-
-            if setting.priority != target_priority:
-                continue
-
-            # 배치되지 않은 숨은 설정값은 무시하고 실제 슬롯 순서만 반영
-            skill_sequence.append(skill_ref)
-
-    for skill_ref in placed_refs:
-        if skill_ref not in skill_sequence:
-            skill_sequence.append(skill_ref)
-
-    return skill_sequence
 
 
 def _reset_cooltime_state(placed_refs: list[EquippedSkillRef]) -> None:
@@ -598,22 +567,19 @@ def _collect_ready_cooltime_skills(
         app_state.macro.prepared_skills & placed_ref_set
     )
     now: float = time.perf_counter()
-    cooltimes: dict[EquippedSkillRef, float] = {
-        skill_ref: app_state.macro.current_server.skill_registry.get(
-            app_state.macro.current_preset.skills.get_placed_skill_id(skill_ref)
-        ).cooltime
-        * (100 - app_state.macro.current_cooltime_reduction)
-        / 100.0
-        for skill_ref in placed_refs
-    }
-
+    cooltimes_ms: dict[EquippedSkillRef, int] = build_skill_cooltimes_ms(
+        server_spec=app_state.macro.current_server,
+        preset=app_state.macro.current_preset,
+        cooltime_reduction=app_state.macro.current_cooltime_reduction,
+    )
     # 쿨타임이 지난 스킬을 준비 완료 상태로 반영
     for skill_ref in placed_refs:
         if skill_ref in prepared_skills:
             continue
 
         started_at: float = app_state.macro.skill_cooltime_timers[skill_ref]
-        if (now - started_at) >= cooltimes[skill_ref]:
+        elapsed_ms: int = round((now - started_at) * 1000)
+        if elapsed_ms >= cooltimes_ms[skill_ref]:
             prepared_skills.add(skill_ref)
 
     return prepared_skills
@@ -670,32 +636,22 @@ def init_macro() -> None:
     _clear_injected_key_events()
     app_state.macro.afk_started_time = time.time()
     app_state.macro.has_pending_afk_notice = False
-    app_state.macro.skill_sequence = _collect_priority_skill_sequence()
-    app_state.macro.using_link_skills.clear()
-    app_state.macro.attack_pause_until = 0.0
-
-    skill_ref_map: dict[str, EquippedSkillRef] = (
-        app_state.macro.current_preset.skills.get_placed_skill_ref_map(
-            app_state.macro.current_server
+    app_state.macro.skill_sequence = list(
+        build_priority_skill_sequence(
+            server_spec=app_state.macro.current_server,
+            preset=app_state.macro.current_preset,
+            skills_info=app_state.macro.current_preset.usage_settings,
         )
     )
-
-    # 자동 연계의 장착 참조 변환
-    for link_skill in app_state.macro.current_preset.link_skills:
-        if link_skill.use_type != LinkUseType.AUTO:
-            continue
-
-        if not all(skill_id in skill_ref_map for skill_id in link_skill.skills):
-            continue
-
-        app_state.macro.using_link_skills.append(
-            [skill_ref_map[skill_id] for skill_id in link_skill.skills]
+    app_state.macro.using_link_skills = [
+        list(link_skill_group)
+        for link_skill_group in build_auto_link_skill_groups(
+            server_spec=app_state.macro.current_server,
+            preset=app_state.macro.current_preset,
         )
-
-    app_state.macro.link_skills_requirements = [
-        [skill_ref for skill_ref in link_skill]
-        for link_skill in app_state.macro.using_link_skills
     ]
+    app_state.macro.attack_pause_until = 0.0
+
     app_state.macro.task_list.clear()
     _restore_or_reset_cooltime_state(placed_refs)
 
@@ -712,7 +668,6 @@ def use_skill(current_line_index: int) -> tuple[bool, int]:
     kbd_controller: keyboard.Controller = keyboard.Controller()
     mouse_controller: mouse.Controller = mouse.Controller()
     skill_ref: EquippedSkillRef = app_state.macro.task_list.pop(0)
-    app_state.macro.skill_cooltime_timers[skill_ref] = time.perf_counter()
 
     current_line_index = _press_skill_keys(
         kbd_controller,
@@ -720,15 +675,18 @@ def use_skill(current_line_index: int) -> tuple[bool, int]:
         skill_ref,
         current_line_index=current_line_index,
     )
+    skill_used_at: float = time.perf_counter()
+    app_state.macro.skill_cooltime_timers[skill_ref] = skill_used_at
 
     delay_seconds: float = (
         app_state.macro.current_delay * 0.001 * config.macro.SLEEP_COEFFICIENT_NORMAL
     )
+    delay_end_at: float = skill_used_at + delay_seconds
 
     # 옵션 활성화 시 스킬 사용 후 1번 줄로 복귀
     if app_state.macro.current_always_return_to_first_line and current_line_index != 0:
         half_delay_seconds: float = delay_seconds * 0.5
-        _sleep_while_macro_running(half_delay_seconds)
+        _wait_until_while_macro_running(skill_used_at + half_delay_seconds)
         current_line_index = _restore_first_line_state(
             kbd_controller,
             mouse_controller,
@@ -736,11 +694,11 @@ def use_skill(current_line_index: int) -> tuple[bool, int]:
         )
 
         if app_state.macro.is_running:
-            _sleep_while_macro_running(half_delay_seconds)
+            _wait_until_while_macro_running(delay_end_at)
 
         return True, current_line_index
 
-    time.sleep(delay_seconds)
+    _wait_until_while_macro_running(delay_end_at)
     return True, current_line_index
 
 
@@ -836,44 +794,6 @@ def use_link_skill(link_skill: LinkSkill) -> None:
             is_input_sequence_running = False
 
 
-def _pop_next_regular_task(
-    prepared_skills: set[EquippedSkillRef],
-    skill_sequence: list[EquippedSkillRef],
-    link_skills_requirements: list[list[EquippedSkillRef]],
-) -> EquippedSkillRef | None:
-    """우선순위 기준 다음 일반 스킬 선택"""
-
-    # 자동 연계에 속한 스킬 참조 집합 구성
-    linked_skill_refs: set[EquippedSkillRef] = {
-        skill_ref
-        for requirements in link_skills_requirements
-        for skill_ref in requirements
-    }
-
-    # 우선순위 순서대로 사용 가능한 첫 스킬 선택
-    for skill_ref in skill_sequence:
-        if skill_ref not in prepared_skills:
-            continue
-
-        skill_id: str = app_state.macro.current_preset.skills.get_placed_skill_id(
-            skill_ref
-        )
-        setting: SkillUsageSetting = app_state.macro.current_preset.usage_settings[
-            skill_id
-        ]
-        in_link_skill: bool = skill_ref in linked_skill_refs
-        can_use: bool = (in_link_skill and setting.use_alone) or (
-            not in_link_skill and setting.use_skill
-        )
-        if not can_use:
-            continue
-
-        prepared_skills.discard(skill_ref)
-        return skill_ref
-
-    return None
-
-
 def build_task_list(show_info: bool = False) -> float:
     """task_list에 사용할 스킬 추가. task_list가 비어있으면 다음 스킬 준비까지 남은 시간(초)을 반환, 아니면 0.0 반환"""
 
@@ -882,14 +802,11 @@ def build_task_list(show_info: bool = False) -> float:
             app_state.macro.current_server
         )
     )
-    cooltimes: dict[EquippedSkillRef, float] = {
-        skill_ref: app_state.macro.current_server.skill_registry.get(
-            app_state.macro.current_preset.skills.get_placed_skill_id(skill_ref)
-        ).cooltime
-        * (100 - app_state.macro.current_cooltime_reduction)
-        / 100.0
-        for skill_ref in placed_refs
-    }
+    cooltimes_ms: dict[EquippedSkillRef, int] = build_skill_cooltimes_ms(
+        server_spec=app_state.macro.current_server,
+        preset=app_state.macro.current_preset,
+        cooltime_reduction=app_state.macro.current_cooltime_reduction,
+    )
     now: float = time.perf_counter()
 
     # 쿨타임 완료 스킬 재준비
@@ -898,30 +815,20 @@ def build_task_list(show_info: bool = False) -> float:
             continue
 
         started_at: float = app_state.macro.skill_cooltime_timers[skill_ref]
-        if (now - started_at) >= cooltimes[skill_ref]:
+        elapsed_ms: int = round((now - started_at) * 1000)
+        if elapsed_ms >= cooltimes_ms[skill_ref]:
             app_state.macro.prepared_skills.add(skill_ref)
 
-    prepared_link_skill_indices: list[int] = get_prepared_link_skill_indices(
+    next_task: tuple[EquippedSkillRef, ...] = take_next_task(
+        preset=app_state.macro.current_preset,
+        skills_info=app_state.macro.current_preset.usage_settings,
         prepared_skills=app_state.macro.prepared_skills,
-        link_skills_requirements=app_state.macro.link_skills_requirements,
+        auto_link_skill_groups=tuple(
+            tuple(link_skill) for link_skill in app_state.macro.using_link_skills
+        ),
+        skill_sequence=tuple(app_state.macro.skill_sequence),
     )
-
-    if prepared_link_skill_indices:
-        for skill_ref in app_state.macro.using_link_skills[
-            prepared_link_skill_indices[0]
-        ]:
-            app_state.macro.prepared_skills.discard(skill_ref)
-            app_state.macro.task_list.append(skill_ref)
-
-    else:
-        # 우선순위 기준 일반 스킬 1개 선택
-        next_regular_skill_ref: EquippedSkillRef | None = _pop_next_regular_task(
-            prepared_skills=app_state.macro.prepared_skills,
-            skill_sequence=app_state.macro.skill_sequence,
-            link_skills_requirements=app_state.macro.link_skills_requirements,
-        )
-        if next_regular_skill_ref is not None:
-            app_state.macro.task_list.append(next_regular_skill_ref)
+    app_state.macro.task_list.extend(next_task)
 
     if DEBUG_PRINT_INFO and show_info:
         print_macro_info(brief=False)
@@ -930,14 +837,24 @@ def build_task_list(show_info: bool = False) -> float:
         return 0.0
 
     # 모든 스킬이 쿨타임 중인 경우, 가장 빨리 준비되는 스킬까지 남은 시간 반환
-    remaining_times: list[float] = [
-        cooltimes[skill_ref] - (now - app_state.macro.skill_cooltime_timers[skill_ref])
+    remaining_times_ms: list[int] = [
+        cooltimes_ms[skill_ref]
+        - round(
+            (
+                now - app_state.macro.skill_cooltime_timers[skill_ref]
+            )
+            * 1000
+        )
         for skill_ref in placed_refs
         if skill_ref not in app_state.macro.prepared_skills
     ]
 
-    # 약간의 여유 시간을 추가하여 실제 준비 시점과의 오차 완화 (추후 설정 가능하게 개선 예정)
-    return max(0.0, min(remaining_times) + 0.2) if remaining_times else 0.0
+    # 조기 기상은 다음 루프에서 남은 시간을 다시 계산하므로 고정 여유시간 없이 정확한 시점 대기
+    return (
+        max(0, min(remaining_times_ms)) * 0.001
+        if remaining_times_ms
+        else 0.0
+    )
 
 
 def build_preview_task_list() -> tuple[EquippedSkillRef, ...]:
@@ -945,29 +862,20 @@ def build_preview_task_list() -> tuple[EquippedSkillRef, ...]:
 
     # 프리뷰 전용 상태 스냅샷 구성
     preview_state: PreviewTaskState = _build_preview_task_state()
-
-    prepared_link_skill_indices: list[int] = get_prepared_link_skill_indices(
-        prepared_skills=preview_state.prepared_skills,
-        link_skills_requirements=preview_state.link_skills_requirements,
-    )
-
-    # 자동 연계가 준비된 경우 실제 실행 순서와 동일하게 먼저 추가
-    for prepared_link_skill_index in prepared_link_skill_indices:
-        for skill_ref in preview_state.using_link_skills[prepared_link_skill_index]:
-            preview_state.prepared_skills.discard(skill_ref)
-            preview_state.task_list.append(skill_ref)
-
-    # 남은 일반 스킬을 우선순위대로 추가
     while True:
-        next_regular_skill_ref: EquippedSkillRef | None = _pop_next_regular_task(
+        next_task: tuple[EquippedSkillRef, ...] = take_next_task(
+            preset=app_state.macro.current_preset,
+            skills_info=app_state.macro.current_preset.usage_settings,
             prepared_skills=preview_state.prepared_skills,
-            skill_sequence=preview_state.skill_sequence,
-            link_skills_requirements=preview_state.link_skills_requirements,
+            auto_link_skill_groups=tuple(
+                tuple(link_skill) for link_skill in preview_state.using_link_skills
+            ),
+            skill_sequence=tuple(preview_state.skill_sequence),
         )
-        if next_regular_skill_ref is None:
+        if not next_task:
             break
 
-        preview_state.task_list.append(next_regular_skill_ref)
+        preview_state.task_list.extend(next_task)
 
     return tuple(preview_state.task_list)
 
@@ -984,10 +892,6 @@ def _build_preview_task_state() -> PreviewTaskState:
             using_link_skills=[
                 link_skill.copy() for link_skill in app_state.macro.using_link_skills
             ],
-            link_skills_requirements=[
-                requirements.copy()
-                for requirements in app_state.macro.link_skills_requirements
-            ],
         )
 
     # 미실행 중에는 프리뷰 전용 상태를 별도로 구성
@@ -996,25 +900,13 @@ def _build_preview_task_state() -> PreviewTaskState:
             app_state.macro.current_server
         )
     )
-    skill_ref_map: dict[str, EquippedSkillRef] = (
-        app_state.macro.current_preset.skills.get_placed_skill_ref_map(
-            app_state.macro.current_server
+    using_link_skills: list[list[EquippedSkillRef]] = [
+        list(link_skill_group)
+        for link_skill_group in build_auto_link_skill_groups(
+            server_spec=app_state.macro.current_server,
+            preset=app_state.macro.current_preset,
         )
-    )
-    using_link_skills: list[list[EquippedSkillRef]] = []
-
-    # 현재 배치 기준으로 실행 가능한 자동 연계만 프리뷰 대상에 포함
-    link_skill: LinkSkill
-    for link_skill in app_state.macro.current_preset.link_skills:
-        if link_skill.use_type != LinkUseType.AUTO:
-            continue
-
-        if not all(skill_id in skill_ref_map for skill_id in link_skill.skills):
-            continue
-
-        using_link_skills.append(
-            [skill_ref_map[skill_id] for skill_id in link_skill.skills]
-        )
+    ]
 
     prepared_skills: set[EquippedSkillRef]
     if (
@@ -1031,33 +923,15 @@ def _build_preview_task_state() -> PreviewTaskState:
     return PreviewTaskState(
         prepared_skills=prepared_skills,
         task_list=[],
-        skill_sequence=_collect_priority_skill_sequence(),
+        skill_sequence=list(
+            build_priority_skill_sequence(
+                server_spec=app_state.macro.current_server,
+                preset=app_state.macro.current_preset,
+                skills_info=app_state.macro.current_preset.usage_settings,
+            )
+        ),
         using_link_skills=using_link_skills,
-        link_skills_requirements=[
-            [skill_ref for skill_ref in link_skill] for link_skill in using_link_skills
-        ],
     )
-
-
-def get_prepared_link_skill_indices(
-    prepared_skills: set[EquippedSkillRef],
-    link_skills_requirements: list[list[EquippedSkillRef]],
-) -> list[int]:
-    """준비된 연계스킬 목록 반환"""
-
-    prepared_indices: list[int] = []
-    copied_prepared_skills: set[EquippedSkillRef] = prepared_skills.copy()
-
-    for idx, requirements in enumerate(link_skills_requirements):
-        if not all(skill_ref in copied_prepared_skills for skill_ref in requirements):
-            continue
-
-        for skill_ref in requirements:
-            copied_prepared_skills.discard(skill_ref)
-
-        prepared_indices.append(idx)
-
-    return prepared_indices
 
 
 def print_macro_info(brief: bool = False) -> None:
@@ -1072,4 +946,3 @@ def print_macro_info(brief: bool = False) -> None:
 
     print("스킬 정렬 순서:", app_state.macro.skill_sequence)
     print("연계스킬 스킬 리스트:", app_state.macro.using_link_skills)
-    print("연계스킬에 필요한 스킬 리스트:", app_state.macro.link_skills_requirements)

--- a/tests/test_macro_runtime.py
+++ b/tests/test_macro_runtime.py
@@ -7,6 +7,7 @@ from pynput.keyboard import KeyCode
 
 import app.scripts.run_macro as run_macro
 from app.scripts.app_state import app_state
+from app.scripts.calculator_engine import SkillUseEvent, build_skill_use_sequence
 from app.scripts.macro_models import (
     EquippedSkillRef,
     LinkKeyType,
@@ -15,10 +16,10 @@ from app.scripts.macro_models import (
     MacroPreset,
     SkillUsageSetting,
 )
+from app.scripts.macro_scheduler import build_priority_skill_sequence
 from app.scripts.registry.key_registry import KeyRegistry, KeySpec
 from app.scripts.registry.server_registry import ServerSpec, server_registry
 from app.scripts.run_macro import (
-    _collect_priority_skill_sequence,
     _restore_or_reset_cooltime_state,
     _settle_cooltime_state_after_stop,
     build_preview_task_list,
@@ -125,9 +126,14 @@ def test_build_task_list_selects_priority_skill(
     placed_refs: list[EquippedSkillRef] = (
         macro_state_with_preset.skills.get_placed_skill_refs(synthetic_server)
     )
-    app_state.macro.skill_sequence = _collect_priority_skill_sequence()
+    app_state.macro.skill_sequence = list(
+        build_priority_skill_sequence(
+            server_spec=synthetic_server,
+            preset=macro_state_with_preset,
+            skills_info=macro_state_with_preset.usage_settings,
+        )
+    )
     app_state.macro.prepared_skills = set(placed_refs)
-    app_state.macro.link_skills_requirements = []
     app_state.macro.using_link_skills = []
     app_state.macro.task_list = []
 
@@ -155,9 +161,14 @@ def test_build_task_list_runs_prepared_auto_link_first(
     link_refs: list[EquippedSkillRef] = [placed_refs[3], placed_refs[7]]
 
     # 연계 요구/실행 목록을 런타임 상태에 직접 구성
-    app_state.macro.skill_sequence = _collect_priority_skill_sequence()
+    app_state.macro.skill_sequence = list(
+        build_priority_skill_sequence(
+            server_spec=synthetic_server,
+            preset=macro_state_with_preset,
+            skills_info=macro_state_with_preset.usage_settings,
+        )
+    )
     app_state.macro.prepared_skills = set(placed_refs)
-    app_state.macro.link_skills_requirements = [list(link_refs)]
     app_state.macro.using_link_skills = [list(link_refs)]
     app_state.macro.task_list = []
 
@@ -165,6 +176,104 @@ def test_build_task_list_runs_prepared_auto_link_first(
 
     assert wait_seconds == 0.0
     assert app_state.macro.task_list == link_refs
+
+
+def test_build_task_list_returns_exact_cooldown_wait_without_fixed_margin(
+    synthetic_server: ServerSpec,
+    macro_state_with_preset: MacroPreset,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """쿨타임 대기의 임의 고정 지연 없는 밀리초 기준 계산 검증"""
+
+    placed_refs: list[EquippedSkillRef] = (
+        macro_state_with_preset.skills.get_placed_skill_refs(synthetic_server)
+    )
+    app_state.macro.skill_sequence = list(
+        build_priority_skill_sequence(
+            server_spec=synthetic_server,
+            preset=macro_state_with_preset,
+            skills_info=macro_state_with_preset.usage_settings,
+        )
+    )
+    app_state.macro.prepared_skills = set()
+    app_state.macro.using_link_skills = []
+    app_state.macro.task_list = []
+    app_state.macro.skill_cooltime_timers = {
+        skill_ref: 100.0 for skill_ref in placed_refs
+    }
+    monkeypatch.setattr(run_macro.time, "perf_counter", lambda: 101.0)
+
+    wait_seconds: float = build_task_list()
+
+    shortest_cooltime: float = min(
+        synthetic_server.skill_registry.get(
+            macro_state_with_preset.skills.get_placed_skill_id(skill_ref)
+        ).cooltime
+        for skill_ref in placed_refs
+    )
+    assert wait_seconds == shortest_cooltime - 1.0
+
+
+def test_runtime_scheduler_matches_60_second_simulation_sequence(
+    synthetic_server: ServerSpec,
+    macro_state_with_preset: MacroPreset,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """가상 시계에서 런타임과 시뮬레이터의 전체 상태 일치 검증"""
+
+    first_link_skill_id: str = macro_state_with_preset.skills.placed_skills[1]
+    second_link_skill_id: str = macro_state_with_preset.skills.placed_skills[6]
+    macro_state_with_preset.link_skills.append(
+        LinkSkill(
+            use_type=LinkUseType.AUTO,
+            skills=[first_link_skill_id, second_link_skill_id],
+        )
+    )
+    delay_ms: int = 300
+    expected_events: tuple[SkillUseEvent, ...] = build_skill_use_sequence(
+        server_spec=synthetic_server,
+        preset=macro_state_with_preset,
+        skills_info=macro_state_with_preset.usage_settings,
+        delay_ms=delay_ms,
+        cooltime_reduction=0.0,
+    )
+
+    started_at: float = 100.0
+    current_time_seconds: float = 0.0
+    monkeypatch.setattr(
+        run_macro.time,
+        "perf_counter",
+        lambda: started_at + current_time_seconds,
+    )
+    init_macro()
+
+    actual_events: list[SkillUseEvent] = []
+    while current_time_seconds < 60.0:
+        wait_seconds: float = 0.0
+        if not app_state.macro.task_list:
+            wait_seconds = build_task_list()
+
+        if app_state.macro.task_list:
+            skill_ref: EquippedSkillRef = app_state.macro.task_list.pop(0)
+            skill_id: str = macro_state_with_preset.skills.get_placed_skill_id(
+                skill_ref
+            )
+            app_state.macro.skill_cooltime_timers[skill_ref] = (
+                run_macro.time.perf_counter()
+            )
+            actual_events.append(
+                SkillUseEvent(
+                    skill_id=skill_id,
+                    time=round(current_time_seconds, 3),
+                )
+            )
+            current_time_seconds += delay_ms * 0.001
+            continue
+
+        assert wait_seconds > 0.0
+        current_time_seconds += wait_seconds
+
+    assert tuple(actual_events) == expected_events
 
 
 def test_cooltime_state_resets_when_remembering_is_disabled(
@@ -310,7 +419,6 @@ def test_init_macro_uses_only_fully_placed_auto_links(
         skill_ref_map[skill_id] for skill_id in valid_skill_ids
     ]
     assert app_state.macro.using_link_skills == [expected_link]
-    assert app_state.macro.link_skills_requirements == [expected_link]
     assert app_state.macro.prepared_skills == set(placed_refs)
 
 


### PR DESCRIPTION
## 변경 사항

- 런타임과 시뮬레이터의 스킬 선택 및 쿨타임 계산을 공통화했습니다.
- 쿨타임 대기의 고정 0.2초 지연을 제거했습니다.
- 밀리초 및 절대 시각 기준으로 실행 시간을 정교화했습니다.
- 런타임과 시뮬레이터의 60초 실행 일치 테스트를 추가했습니다.

## 테스트

- 전체 테스트 240개 통과