### PR TITLE
Feature/armor hp scrolls

### DIFF
--- a/app/scripts/character_data.py
+++ b/app/scripts/character_data.py
@@ -999,6 +999,31 @@ ARMOR_SCROLL_STAT_VALUES: dict[ScrollTier, float] = {
     ScrollTier.SIXTY: 2.0,
     ScrollTier.HUNDRED: 1.0,
 }
+ARMOR_HP_SCROLL_EFFECTS: dict[
+    StatKey,
+    dict[ScrollTier, dict[StatKey, float]],
+] = {
+    StatKey.HP: {
+        ScrollTier.TEN: _stats((StatKey.HP, 25.0)),
+        ScrollTier.TWENTY: _stats((StatKey.HP, 20.0)),
+        ScrollTier.FIFTY: _stats((StatKey.HP, 15.0)),
+        ScrollTier.SIXTY: _stats((StatKey.HP, 10.0)),
+        ScrollTier.HUNDRED: _stats((StatKey.HP, 5.0)),
+    },
+    StatKey.HP_PERCENT: {
+        ScrollTier.TEN: _stats(
+            (StatKey.HP_PERCENT, 5.0),
+            (StatKey.ATTACK, 4.0),
+        ),
+        ScrollTier.TWENTY: _stats(
+            (StatKey.HP_PERCENT, 4.0),
+            (StatKey.ATTACK, 2.0),
+        ),
+        ScrollTier.FIFTY: _stats((StatKey.HP_PERCENT, 3.0)),
+        ScrollTier.SIXTY: _stats((StatKey.HP_PERCENT, 2.0)),
+        ScrollTier.HUNDRED: _stats((StatKey.HP_PERCENT, 1.0)),
+    },
+}
 
 
 def _build_armor_scroll_effects(
@@ -1034,6 +1059,7 @@ def _build_armor_scroll_effects(
         )
         for tier in ARMOR_SCROLL_STAT_VALUES
     }
+    effects.update(ARMOR_HP_SCROLL_EFFECTS)
     return effects
 
 

--- a/app/scripts/ui/character_ui/tabs/equipment_tab.py
+++ b/app/scripts/ui/character_ui/tabs/equipment_tab.py
@@ -2038,6 +2038,7 @@ class EquipmentTab(CharacterTab):
             add_text=self._scroll_add_button_text(slot.slot, item),
             add_clicked=lambda: self._add_selected_scroll(slot.slot, item),
             option_title="확률",
+            wrap_group=True,
             selector_scroll_min_height=150,
             list_scroll_min_height=150,
         )
@@ -2059,7 +2060,7 @@ class EquipmentTab(CharacterTab):
             stat_buttons[stat_key] = stat_button
             panels.group_layout.addWidget(stat_button)
 
-        panels.group_layout.addStretch(1)
+        panels.add_group_stretch()
         tier_buttons: dict[ScrollTier, QPushButton] = {}
         for tier, effects in tier_effects.items():
             tier_button: QPushButton = self._build_scroll_tier_button(

--- a/app/scripts/ui/character_ui/tabs/talisman_tab.py
+++ b/app/scripts/ui/character_ui/tabs/talisman_tab.py
@@ -163,6 +163,7 @@ class TalismanTab(CharacterTab):
             add_text="+ 부적 추가",
             add_clicked=self._add_talisman,
             option_title="종류",
+            wrap_group=False,
             selector_min_width=320,
             list_min_width=_OWNED_TALISMAN_WIDTH,
             selector_scroll_min_height=210,
@@ -181,7 +182,7 @@ class TalismanTab(CharacterTab):
             self._grade_buttons[grade] = grade_button
             self._choice_panels.group_layout.addWidget(grade_button)
 
-        self._choice_panels.group_layout.addStretch(1)
+        self._choice_panels.add_group_stretch()
         return self._choice_panels.selector_panel
 
     def _build_owned_panel(self) -> QFrame:

--- a/app/scripts/ui/character_ui/widgets.py
+++ b/app/scripts/ui/character_ui/widgets.py
@@ -317,6 +317,7 @@ class ChoiceListPanels:
         add_clicked: Callable[[], None],
         # selector 아래쪽 제목
         option_title: str,
+        wrap_group: bool,
         selector_min_width: int = 0,
         list_min_width: int = 0,
         selector_scroll_min_height: int = 150,
@@ -336,9 +337,13 @@ class ChoiceListPanels:
         )
 
         self.group_container: QFrame = QFrame(self.selector_panel)
-        self.group_layout = QHBoxLayout(self.group_container)
-        self.group_layout.setContentsMargins(0, 0, 0, 0)
-        self.group_layout.setSpacing(6)
+        self.group_layout: QLayout
+        if wrap_group:
+            self.group_layout = FlowLayout(self.group_container, spacing=6)
+        else:
+            self.group_layout = QHBoxLayout(self.group_container)
+            self.group_layout.setContentsMargins(0, 0, 0, 0)
+            self.group_layout.setSpacing(6)
         selector_layout.addWidget(self.group_container)
 
         selector_layout.addWidget(
@@ -386,6 +391,12 @@ class ChoiceListPanels:
         )
 
         list_panel_layout.addWidget(self.list_scroll_area, 1)
+
+    def add_group_stretch(self) -> None:
+        """고정 행 레이아웃의 선택 버튼을 왼쪽 정렬"""
+
+        if isinstance(self.group_layout, QBoxLayout):
+            self.group_layout.addStretch(1)
 
     def make_choice_button(
         self,


### PR DESCRIPTION
투구·갑옷·허리띠·신발에 체력·체력% 주문서를 추가하고, 좁은 화면에서 주문서 종류가 줄바꿈되도록 개선했습니다.

- 전체 256개 테스트 통과