### PR TITLE
실시간 보스데미지 상한 제거

### DIFF
--- a/app/scripts/character_engine.py
+++ b/app/scripts/character_engine.py
@@ -65,7 +65,6 @@ from app.scripts.character_models import (
 
 CHARACTER_BASE_HP: float = 50.0
 CHARACTER_HP_PER_LEVEL: float = 5.0
-LIVE_POWER_DISPLAY_LIMIT: float = 1_000_000.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -950,7 +949,7 @@ def _evaluate_live_power_metric(
         return 0.0
 
     power_value: float = evaluate_builtin_power_metric(final_stats, power_metric)
-    if not isfinite(power_value) or power_value >= LIVE_POWER_DISPLAY_LIMIT:
+    if not isfinite(power_value):
         return 0.0
 
     return power_value


### PR DESCRIPTION
캐릭터 실시간 스탯의 보스데미지 기댓값 100만 제한을 제거했습니다.

- 캐릭터 엔진 테스트 18개 통과