### PR TITLE
추가 스탯 그룹 추가 및 수치 입력 상한 수정

### DIFF
--- a/app/scripts/character_engine.py
+++ b/app/scripts/character_engine.py
@@ -48,6 +48,7 @@ from app.scripts.character_models import (
     MAX_TALISMAN_LEVEL,
     TALISMAN_SPECS,
     AdditionalLine,
+    AdditionalStatGroup,
     CharacterProfile,
     CharacterStore,
     CharacterTalisman,
@@ -553,6 +554,20 @@ def _validate_consumables(profile: CharacterProfile) -> None:
             raise ValueError("pill is not supported")
 
 
+def _validate_additional_stat_groups(profile: CharacterProfile) -> None:
+    """추가 스탯 그룹 입력 검증"""
+
+    for group in profile.additional_stat_groups:
+        if not group.name.strip():
+            raise ValueError("additional stat group name is required")
+
+        for stat in group.stats:
+            if not isfinite(stat.value):
+                raise ValueError("additional stat value must be finite")
+
+            _validate_non_negative_float(stat.value, "additional stat value")
+
+
 def validate_character_profile(profile: CharacterProfile) -> None:
     """캐릭터 프로필 전체 검증"""
 
@@ -563,6 +578,7 @@ def validate_character_profile(profile: CharacterProfile) -> None:
     _validate_equipment_state(profile)
     _validate_display_stand(profile)
     _validate_consumables(profile)
+    _validate_additional_stat_groups(profile)
 
 
 def validate_character_store(store: CharacterStore) -> None:
@@ -904,6 +920,17 @@ def _add_pills(
         _merge_stats(accumulated, PILL_SPECS[pill].effects)
 
 
+def _add_additional_stat_groups(
+    accumulated: dict[StatKey, float],
+    groups: list[AdditionalStatGroup],
+) -> None:
+    """추가 스탯 그룹 기여 누적"""
+
+    for group in groups:
+        for stat in group.stats:
+            _add_stat(accumulated, stat.stat_key, stat.value)
+
+
 def _accumulate_pill_excluded_base_stats(
     profile: CharacterProfile,
 ) -> dict[StatKey, float]:
@@ -917,6 +944,7 @@ def _accumulate_pill_excluded_base_stats(
     _add_equipment(accumulated, profile)
     _add_display_stand(accumulated, profile)
     _add_elixirs(accumulated, profile)
+    _add_additional_stat_groups(accumulated, profile.additional_stat_groups)
     return accumulated
 
 

--- a/app/scripts/character_models.py
+++ b/app/scripts/character_models.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 from app.scripts.calculator_models import RealmTier, StatKey
 from app.scripts.registry.resource_registry import convert_resource_path
 
-CHARACTER_DATA_VERSION: int = 1
+CHARACTER_DATA_VERSION: int = 2
 DEFAULT_CHARACTER_NAME: str = "새 캐릭터"
 TITLE_STAT_SLOT_COUNT: int = 3
 EQUIPMENT_OPTION_SLOT_COUNT: int = 3
@@ -18,6 +18,7 @@ MAX_CHARACTER_LEVEL: int = 200
 MAX_TALISMAN_LEVEL: int = 14
 MAX_ELIXIR_COUNT: int = 10
 MAX_REFORGE_STEP: int = 20
+MAX_CHARACTER_INPUT_VALUE: float = 999.99
 
 
 class EquipmentSlot(str, Enum):
@@ -692,6 +693,58 @@ class PillState:
 
 
 @dataclass(slots=True)
+class AdditionalStatLine:
+    """추가 스탯 입력 라인"""
+
+    stat_key: StatKey
+    value: float
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "AdditionalStatLine":
+        """저장 데이터로부터 추가 스탯 라인 복원"""
+
+        return cls(
+            stat_key=StatKey(str(data["stat_key"])),
+            value=float(data["value"]),
+        )
+
+    def to_dict(self) -> dict[str, str | float]:
+        """추가 스탯 라인 직렬화"""
+
+        return {
+            "stat_key": self.stat_key.value,
+            "value": float(self.value),
+        }
+
+
+@dataclass(slots=True)
+class AdditionalStatGroup:
+    """추가 스탯 그룹"""
+
+    name: str = ""
+    stats: list[AdditionalStatLine] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "AdditionalStatGroup":
+        """저장 데이터로부터 추가 스탯 그룹 복원"""
+
+        return cls(
+            name=str(data["name"]),
+            stats=[
+                AdditionalStatLine.from_dict(item) for item in _read_list(data, "stats")
+            ],
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """추가 스탯 그룹 직렬화"""
+
+        return {
+            "name": self.name,
+            "stats": [stat.to_dict() for stat in self.stats],
+        }
+
+
+@dataclass(slots=True)
 class CharacterProfile:
     """전역 캐릭터 프로필"""
 
@@ -709,6 +762,7 @@ class CharacterProfile:
     display_stand: DisplayStandState = field(default_factory=DisplayStandState)
     elixir: ElixirState = field(default_factory=ElixirState)
     pill: PillState = field(default_factory=PillState)
+    additional_stat_groups: list[AdditionalStatGroup] = field(default_factory=list)
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "CharacterProfile":
@@ -736,6 +790,10 @@ class CharacterProfile:
             ),
             elixir=ElixirState.from_dict(_read_dict(data, "elixir")),
             pill=PillState.from_dict(_read_dict(data, "pill")),
+            additional_stat_groups=[
+                AdditionalStatGroup.from_dict(item)
+                for item in _read_list(data, "additional_stat_groups")
+            ],
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -756,6 +814,9 @@ class CharacterProfile:
             "display_stand": self.display_stand.to_dict(),
             "elixir": self.elixir.to_dict(),
             "pill": self.pill.to_dict(),
+            "additional_stat_groups": [
+                group.to_dict() for group in self.additional_stat_groups
+            ],
         }
 
 

--- a/app/scripts/data_manager.py
+++ b/app/scripts/data_manager.py
@@ -365,12 +365,59 @@ def create_default_characters_data() -> None:
         json.dump(default_store.to_dict(), f, ensure_ascii=False, indent=4)
 
 
+def migrate_character_data_file(file_path: str) -> None:
+    """characters.json 저장 구조를 현재 버전으로 마이그레이션"""
+
+    try:
+        with open(file_path, "r", encoding="utf-8") as f:
+            raw_obj: object = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return
+
+    if not isinstance(raw_obj, dict):
+        return
+
+    try:
+        raw: dict[str, Any] = raw_obj
+        if raw.get("version") != 1:
+            return
+
+        raw_characters: object = raw["characters"]
+        if not isinstance(raw_characters, list):
+            return
+
+        for raw_character in raw_characters:
+            if not isinstance(raw_character, dict):
+                return
+
+            raw_character["additional_stat_groups"] = []
+
+        raw["version"] = 2
+
+    except (KeyError, TypeError, ValueError):
+        return
+
+    try:
+        with open(file_path, "w", encoding="utf-8") as f:
+            json.dump(raw, f, ensure_ascii=False, indent=4)
+    except OSError as error:
+        log_text: str = _format_data_failure_log(
+            file_path,
+            "characters.json 마이그레이션 저장",
+            error,
+            None,
+        )
+        raise DataRecoveryStartupError(log_text) from error
+
+
 def load_characters() -> CharacterStore:
     """characters.json 로드 후 전역 캐릭터 상태에 반영"""
 
     # 최초 실행 시 빈 캐릭터 저장소 파일 생성
     if not os.path.isfile(characters_file_dir):
         create_default_characters_data()
+
+    migrate_character_data_file(characters_file_dir)
 
     try:
         # 캐릭터 저장 루트 로드

--- a/app/scripts/ui/character_ui/character_page.py
+++ b/app/scripts/ui/character_ui/character_page.py
@@ -34,6 +34,7 @@ from app.scripts.data_manager import save_characters
 from app.scripts.ui.character_ui.change_handler import CharacterChangeHandler
 from app.scripts.ui.character_ui.panels.character_list import CharacterListPanel
 from app.scripts.ui.character_ui.panels.live_stats import LiveStatsPanel
+from app.scripts.ui.character_ui.tabs.additional_stats_tab import AdditionalStatsTab
 from app.scripts.ui.character_ui.tabs.base import CharacterTab
 from app.scripts.ui.character_ui.tabs.display_stand_tab import DisplayStandTab
 from app.scripts.ui.character_ui.tabs.distribution_tab import DistributionTab
@@ -56,6 +57,7 @@ _CHARACTER_TABS: tuple[tuple[str, type[CharacterTab]], ...] = (
     ("부적", TalismanTab),
     ("영단", ElixirTab),
     ("환", PillEffectTab),
+    ("추가 스탯", AdditionalStatsTab),
 )
 
 

--- a/app/scripts/ui/character_ui/tabs/additional_stats_tab.py
+++ b/app/scripts/ui/character_ui/tabs/additional_stats_tab.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+from app.scripts.calculator_models import STAT_SPECS, StatKey
+from app.scripts.character_models import (
+    AdditionalStatGroup,
+    AdditionalStatLine,
+    CharacterProfile,
+)
+from app.scripts.custom_classes import CustomFont, StyledButton
+from app.scripts.ui.character_ui.change_handler import CharacterChangeHandler
+from app.scripts.ui.character_ui.constants import STAT_LABEL_TO_KEY
+from app.scripts.ui.character_ui.tabs.base import CharacterTab
+from app.scripts.ui.character_ui.widgets import CharCard, CharComboBox, StepperField
+
+
+class _AdditionalStatGroupItem(QFrame):
+    """추가 스탯 그룹 입력 카드"""
+
+    def __init__(
+        self,
+        parent: QWidget,
+        index: int,
+        group: AdditionalStatGroup,
+        changes: CharacterChangeHandler,
+        on_delete: Callable[[int], None],
+        on_rebuild: Callable[[], None],
+    ) -> None:
+        super().__init__(parent)
+
+        self.setObjectName("charStatGroupItem")
+        self._group: AdditionalStatGroup = group
+        self._changes: CharacterChangeHandler = changes
+        self._on_rebuild: Callable[[], None] = on_rebuild
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(14, 14, 14, 14)
+        layout.setSpacing(10)
+
+        head = QHBoxLayout()
+        head.setSpacing(10)
+
+        self._name_edit: QLineEdit = QLineEdit(group.name, self)
+        self._name_edit.setObjectName("charTitleName")
+        self._name_edit.setFont(CustomFont(12, bold=True))
+        self._name_edit.editingFinished.connect(self._commit_name)
+
+        delete_group_btn: StyledButton = StyledButton(
+            self,
+            "그룹 삭제",
+            kind="danger",
+            point_size=9,
+        )
+        delete_group_btn.clicked.connect(
+            lambda _checked=False, group_index=index: on_delete(group_index)
+        )
+
+        head.addWidget(self._name_edit, 1)
+        head.addWidget(delete_group_btn)
+        layout.addLayout(head)
+
+        for stat_index, stat in enumerate(group.stats):
+            layout.addLayout(self._build_stat_row(stat_index, stat))
+
+        add_stat_btn: StyledButton = StyledButton(
+            self,
+            "+ 스탯 추가",
+            kind="normal",
+            point_size=9,
+        )
+        add_stat_btn.clicked.connect(self._add_stat)
+        layout.addWidget(add_stat_btn, alignment=Qt.AlignmentFlag.AlignLeft)
+
+    def _build_stat_row(
+        self,
+        index: int,
+        stat: AdditionalStatLine,
+    ) -> QHBoxLayout:
+        """추가 스탯 입력 행 구성"""
+
+        row = QHBoxLayout()
+        row.setSpacing(10)
+
+        combo: CharComboBox = CharComboBox(self, list(STAT_SPECS.values()))
+        combo.setCurrentText(STAT_SPECS[stat.stat_key])
+
+        value_field: StepperField = StepperField(
+            self,
+            f"{stat.value:g}",
+            max_width=160,
+        )
+
+        combo.currentTextChanged.connect(
+            lambda text, target=stat: self._set_stat_key(target, text)
+        )
+        value_field.value_changed.connect(
+            lambda target=stat, field=value_field: self._set_stat_value(
+                target,
+                field.number(),
+            )
+        )
+
+        delete_btn: StyledButton = StyledButton(
+            self,
+            "삭제",
+            kind="danger",
+            point_size=9,
+        )
+        delete_btn.setFixedWidth(54)
+        delete_btn.clicked.connect(
+            lambda _checked=False, row_index=index: self._remove_stat(row_index)
+        )
+
+        row.addWidget(combo, 1)
+        row.addWidget(value_field)
+        row.addWidget(delete_btn)
+        return row
+
+    def _commit_name(self) -> None:
+        """그룹명 변경 반영"""
+
+        name: str = self._name_edit.text().strip()
+        if not name:
+            self._name_edit.setText(self._group.name)
+            return
+
+        if self._group.name == name:
+            return
+
+        self._group.name = name
+        self._name_edit.setText(name)
+        self._changes.saved_value_changed()
+
+    def _set_stat_key(self, stat: AdditionalStatLine, label: str) -> None:
+        """추가 스탯 종류 변경 반영"""
+
+        stat_key: StatKey = STAT_LABEL_TO_KEY[label]
+        if stat.stat_key == stat_key:
+            return
+
+        stat.stat_key = stat_key
+        self._changes.stats_changed()
+
+    def _set_stat_value(self, stat: AdditionalStatLine, value: float) -> None:
+        """추가 스탯 값 변경 반영"""
+
+        if stat.value == value:
+            return
+
+        stat.value = value
+        self._changes.stats_changed()
+
+    def _add_stat(self) -> None:
+        """추가 스탯 입력 행 생성"""
+
+        self._group.stats.append(
+            AdditionalStatLine(stat_key=StatKey.ATTACK, value=0.0)
+        )
+        self._on_rebuild()
+        self._changes.saved_value_changed()
+
+    def _remove_stat(self, index: int) -> None:
+        """추가 스탯 입력 행 삭제"""
+
+        removed: AdditionalStatLine = self._group.stats.pop(index)
+        self._on_rebuild()
+        if removed.value == 0.0:
+            self._changes.saved_value_changed()
+            return
+
+        self._changes.stats_changed()
+
+
+class AdditionalStatsTab(CharacterTab):
+    """추가 스탯 그룹 탭"""
+
+    def __init__(
+        self,
+        parent: QWidget,
+        changes: CharacterChangeHandler,
+        profile: CharacterProfile,
+    ) -> None:
+        super().__init__(parent, changes, profile)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(16)
+
+        card: CharCard = CharCard(self, "추가 스탯 그룹")
+        add_group_btn: StyledButton = StyledButton(
+            self,
+            "+ 그룹 추가",
+            kind="normal",
+            point_size=9,
+        )
+        add_group_btn.clicked.connect(self._add_group)
+        card.add_header_widget(add_group_btn)
+
+        self._groups_container: QWidget = QWidget(self)
+        self._groups_layout = QVBoxLayout(self._groups_container)
+        self._groups_layout.setContentsMargins(0, 0, 0, 0)
+        self._groups_layout.setSpacing(10)
+        card.add_widget(self._groups_container)
+
+        layout.addWidget(card)
+        layout.addStretch(1)
+
+        self._render_groups()
+
+    def set_profile(self, profile: CharacterProfile) -> None:
+        """선택 캐릭터 모델 반영"""
+
+        self._profile = profile
+        self._render_groups()
+
+    def _render_groups(self) -> None:
+        """추가 스탯 그룹 목록 재구성"""
+
+        while self._groups_layout.count():
+            item = self._groups_layout.takeAt(0)
+            widget: QWidget | None = item.widget()  # type: ignore[assignment]
+            if widget is not None:
+                widget.deleteLater()
+
+        if not self._profile.additional_stat_groups:
+            empty_label: QLabel = QLabel("비어 있음", self._groups_container)
+            empty_label.setObjectName("charMuted")
+            empty_label.setFont(CustomFont(10, bold=True))
+            empty_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            self._groups_layout.addWidget(empty_label)
+            return
+
+        for index, group in enumerate(self._profile.additional_stat_groups):
+            self._groups_layout.addWidget(
+                _AdditionalStatGroupItem(
+                    self._groups_container,
+                    index,
+                    group,
+                    self._changes,
+                    self._delete_group,
+                    self._render_groups,
+                )
+            )
+
+    def _add_group(self) -> None:
+        """추가 스탯 그룹 생성"""
+
+        existing_names: set[str] = {
+            group.name for group in self._profile.additional_stat_groups
+        }
+        index: int = 1
+        name: str = f"추가 스탯 그룹 {index}"
+        while name in existing_names:
+            index += 1
+            name = f"추가 스탯 그룹 {index}"
+
+        self._profile.additional_stat_groups.append(AdditionalStatGroup(name=name))
+        self._render_groups()
+        self._changes.saved_value_changed()
+
+    def _delete_group(self, index: int) -> None:
+        """추가 스탯 그룹 삭제"""
+
+        removed: AdditionalStatGroup = self._profile.additional_stat_groups.pop(index)
+        self._render_groups()
+        if any(stat.value != 0.0 for stat in removed.stats):
+            self._changes.stats_changed()
+            return
+
+        self._changes.saved_value_changed()

--- a/app/scripts/ui/character_ui/tabs/distribution_tab.py
+++ b/app/scripts/ui/character_ui/tabs/distribution_tab.py
@@ -14,7 +14,7 @@ from PySide6.QtWidgets import (
 
 from app.scripts.calculator_models import REALM_TIER_SPECS
 from app.scripts.character_engine import optimize_danjeon, optimize_stat_distribution
-from app.scripts.character_models import CharacterProfile
+from app.scripts.character_models import MAX_CHARACTER_LEVEL, CharacterProfile
 from app.scripts.custom_classes import CustomFont, StyledButton
 from app.scripts.ui.character_ui.change_handler import CharacterChangeHandler
 from app.scripts.ui.character_ui.constants import (
@@ -29,6 +29,7 @@ from app.scripts.ui.character_ui.widgets import (
 )
 
 _ITEM_FIELD_WIDTH: int = 84
+_MAX_STAT_DISTRIBUTION_VALUE: int = MAX_CHARACTER_LEVEL * 5
 
 
 class _Budget(QFrame):
@@ -177,7 +178,7 @@ class DistributionTab(CharacterTab):
                 effect,
                 self._recalc_stat,
                 self._stat_fields,
-                max_value=1000,
+                max_value=_MAX_STAT_DISTRIBUTION_VALUE,
             )
             for key, label, effect in STAT_DISTRIBUTION_ITEMS
         ]

--- a/app/scripts/ui/character_ui/tabs/elixir_tab.py
+++ b/app/scripts/ui/character_ui/tabs/elixir_tab.py
@@ -80,6 +80,7 @@ class _ElixirCard(QFrame):
         self._count_field: StepperField = StepperField(
             self,
             "0",
+            max_value=MAX_ELIXIR_COUNT,
             integer=True,
         )
         self._count_field.value_changed.connect(self._on_count)

--- a/app/scripts/ui/character_ui/tabs/equipment_tab.py
+++ b/app/scripts/ui/character_ui/tabs/equipment_tab.py
@@ -1772,6 +1772,7 @@ class EquipmentTab(CharacterTab):
             container,
             str(item.reforge_step),
             unit="강",
+            max_value=MAX_REFORGE_STEP,
             integer=True,
         )
         field.setFixedWidth(84)
@@ -2299,14 +2300,13 @@ class EquipmentTab(CharacterTab):
         box.setContentsMargins(0, 0, 0, 0)
         box.setSpacing(5)
 
-        unit: str = "%" if "%" in label else ""
         box.addWidget(_field_caption(container, label))
 
         # %스탯과 일반 스탯 모두 동일한 칸 폭으로 통일
         field: QWidget = (
-            StaticValueField(container, value, unit=unit)
+            StaticValueField(container, value)
             if readonly
-            else StepperField(container, value, unit=unit)
+            else StepperField(container, value)
         )
         if isinstance(field, StepperField) and on_changed is not None:
             field.value_changed.connect(lambda target=field: on_changed(target))

--- a/app/scripts/ui/character_ui/tabs/talisman_tab.py
+++ b/app/scripts/ui/character_ui/tabs/talisman_tab.py
@@ -618,6 +618,7 @@ class TalismanTab(CharacterTab):
             str(talisman.level),
             unit="Lv",
             max_width=96,
+            max_value=MAX_TALISMAN_LEVEL,
             integer=True,
         )
         level_field.value_changed.connect(

--- a/app/scripts/ui/character_ui/widgets.py
+++ b/app/scripts/ui/character_ui/widgets.py
@@ -26,6 +26,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from app.scripts.character_models import MAX_CHARACTER_INPUT_VALUE
 from app.scripts.custom_classes import CustomFont, StyledButton
 
 
@@ -61,7 +62,7 @@ class NormalizingLineEdit(QLineEdit):
         parent: QWidget | None = None,
         *,
         min_value: float = 0.0,
-        max_value: float = 100.0,
+        max_value: float = MAX_CHARACTER_INPUT_VALUE,
         integer: bool = False,
     ) -> None:
         super().__init__(text, parent)
@@ -70,7 +71,9 @@ class NormalizingLineEdit(QLineEdit):
         if integer:
             self.setValidator(QIntValidator(int(min_value), int(max_value), self))
         else:
-            self.setValidator(QDoubleValidator(min_value, max_value, 2, self))
+            validator = QDoubleValidator(min_value, max_value, 2, self)
+            validator.setNotation(QDoubleValidator.Notation.StandardNotation)
+            self.setValidator(validator)
 
         self.editingFinished.connect(self._commit_value)
 
@@ -149,7 +152,7 @@ class StepperField(QFrame):
         unit: str = "",
         max_width: int = 0,
         min_value: float = 0.0,
-        max_value: float = 100.0,
+        max_value: float = MAX_CHARACTER_INPUT_VALUE,
         integer: bool = False,
     ) -> None:
         super().__init__(parent)

--- a/app/scripts/ui/themes.py
+++ b/app/scripts/ui/themes.py
@@ -1600,8 +1600,8 @@ QFrame#charStatCellEmpty {{ background: transparent; }}
 QLabel#charStatLabel {{ color: #787671; background: transparent; }}
 QLabel#charStatValue {{ color: #1A1A1A; background: transparent; }}
 
-/* 칭호 */
-QFrame#charTitleItem {{
+/* 칭호와 추가 스탯 그룹 */
+QFrame#charTitleItem, QFrame#charStatGroupItem {{
     background-color: #FFFFFF; border: 1px solid #E5E3DF; border-radius: 12px;
 }}
 QFrame#charTitleItem[equipped=true] {{ background-color: #EFECFD; border-color: #9180F7; }}
@@ -3211,8 +3211,8 @@ QFrame#charStatCellEmpty {{ background: transparent; }}
 QLabel#charStatLabel {{ color: #A0A0C0; background: transparent; }}
 QLabel#charStatValue {{ color: #E8E8F0; background: transparent; }}
 
-/* 칭호 */
-QFrame#charTitleItem {{
+/* 칭호와 추가 스탯 그룹 */
+QFrame#charTitleItem, QFrame#charStatGroupItem {{
     background-color: #1E1E2E; border: 1px solid #363650; border-radius: 12px;
 }}
 QFrame#charTitleItem[equipped=true] {{ background-color: #2E2A4A; border-color: #9180F7; }}

--- a/tests/data/golden/character_stats_cases.json
+++ b/tests/data/golden/character_stats_cases.json
@@ -70,7 +70,8 @@
         },
         "pill": {
           "active": []
-        }
+        },
+        "additional_stat_groups": []
       },
       "expected": {
         "final_stats": {
@@ -743,7 +744,8 @@
         },
         "pill": {
           "active": ["추천환"]
-        }
+        },
+        "additional_stat_groups": []
       },
       "expected": {
         "final_stats": {

--- a/tests/test_character_engine.py
+++ b/tests/test_character_engine.py
@@ -26,6 +26,8 @@ from app.scripts.character_engine import (
     validate_character_store,
 )
 from app.scripts.character_models import (
+    AdditionalStatGroup,
+    AdditionalStatLine,
     CharacterProfile,
     CharacterStore,
     CharacterTalisman,
@@ -109,9 +111,7 @@ def test_unknown_equipped_title_is_rejected(basic_profile: CharacterProfile) -> 
 def test_unknown_talisman_key_is_rejected(basic_profile: CharacterProfile) -> None:
     """존재하지 않는 부적 종류의 명시적 거부 검증"""
 
-    basic_profile.talismans.append(
-        CharacterTalisman(talisman_key="없는부적", level=1)
-    )
+    basic_profile.talismans.append(CharacterTalisman(talisman_key="없는부적", level=1))
 
     with pytest.raises(ValueError):
         validate_character_profile(basic_profile)
@@ -144,7 +144,8 @@ def test_live_view_aggregates_inputs_hand_computed(
 
     기본 체력 = 50 + 레벨 * 5
     단전: 상단전 체력% +3/저항% +1, 중단전 공격력% +1
-    칭호: 슬롯 스탯 그대로 합산, VIP: 드랍률% +3
+    칭호: 슬롯 스탯 그대로 합산, 추가 스탯: 같은 그룹의 중복 스탯도 합산
+    VIP: 드랍률% +3
     """
 
     # 공격력 +100, 보스 공격력% +5 칭호 장착 구성
@@ -158,6 +159,15 @@ def test_live_view_aggregates_inputs_hand_computed(
     )
     basic_profile.titles.append(title)
     basic_profile.equipped.title_id = title.id
+    basic_profile.additional_stat_groups.append(
+        AdditionalStatGroup(
+            name="기타",
+            stats=[
+                AdditionalStatLine(stat_key=StatKey.ATTACK, value=20.0),
+                AdditionalStatLine(stat_key=StatKey.ATTACK, value=30.0),
+            ],
+        )
+    )
     basic_profile.vip = True
 
     live: LiveStatView = compute_live_view(basic_profile)
@@ -179,8 +189,8 @@ def test_live_view_aggregates_inputs_hand_computed(
     assert base_values[StatKey.RESIST_PERCENT.value] == pytest.approx(1.0)
     assert base_values[StatKey.ATTACK_PERCENT.value] == pytest.approx(1.0)
 
-    # 칭호와 VIP 반영 확인
-    assert base_values[StatKey.ATTACK.value] == pytest.approx(100.0)
+    # 칭호와 같은 그룹 내 중복 추가 스탯, VIP 반영 확인
+    assert base_values[StatKey.ATTACK.value] == pytest.approx(150.0)
     assert base_values[StatKey.BOSS_ATTACK_PERCENT.value] == pytest.approx(5.0)
     assert base_values[StatKey.DROP_RATE_PERCENT.value] == pytest.approx(3.0)
 
@@ -387,10 +397,7 @@ def test_optimize_stat_distribution_matches_exhaustive_damage_score(
         values: dict[StatKey, float] = compute_live_view(candidate).final.values
         crit_rate: float = min(values[StatKey.CRIT_RATE_PERCENT], 100.0)
         return values[StatKey.ATTACK] * (
-            1.0
-            + crit_rate
-            * (values[StatKey.CRIT_DAMAGE_PERCENT] - 100.0)
-            / 10000.0
+            1.0 + crit_rate * (values[StatKey.CRIT_DAMAGE_PERCENT] - 100.0) / 10000.0
         )
 
     optimized_score: float = damage_score(optimized)

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -12,6 +12,8 @@ from app.scripts import data_manager
 from app.scripts.app_state import app_state
 from app.scripts.character_models import (
     CHARACTER_DATA_VERSION,
+    AdditionalStatGroup,
+    AdditionalStatLine,
     CharacterProfile,
     CharacterStore,
 )
@@ -241,6 +243,36 @@ def test_future_character_version_is_detected(
     assert data_manager.has_future_character_data_version() is True
 
 
+def test_load_characters_migrates_v1_additional_stat_groups(
+    isolated_data_paths: dict[str, str],
+) -> None:
+    """v1 캐릭터 저장값 보존과 빈 추가 스탯 그룹 주입 검증"""
+
+    store_payload: dict[str, Any] = CharacterStore.create_default().to_dict()
+    store_payload["version"] = 1
+    raw_character: dict[str, Any] = store_payload["characters"][0]
+    raw_character["name"] = "마이그레이션 대상"
+    raw_character["level"] = 120
+    raw_character.pop("additional_stat_groups")
+    _write_text(
+        isolated_data_paths["characters_file_dir"],
+        json.dumps(store_payload, ensure_ascii=False),
+    )
+
+    loaded: CharacterStore = data_manager.load_characters()
+
+    assert loaded.version == CHARACTER_DATA_VERSION
+    assert loaded.characters[0].name == "마이그레이션 대상"
+    assert loaded.characters[0].level == 120
+    assert loaded.characters[0].additional_stat_groups == []
+    assert _list_backups(isolated_data_paths["data_path"], "characters") == []
+
+    with open(isolated_data_paths["characters_file_dir"], "r", encoding="utf-8") as f:
+        migrated_payload: dict[str, Any] = json.load(f)
+    assert migrated_payload["version"] == CHARACTER_DATA_VERSION
+    assert migrated_payload["characters"][0]["additional_stat_groups"] == []
+
+
 def test_save_then_load_characters_preserves_state(
     isolated_data_paths: dict[str, str],
 ) -> None:
@@ -249,6 +281,15 @@ def test_save_then_load_characters_preserves_state(
     store: CharacterStore = CharacterStore.create_default()
     store.characters[0].name = "첫 번째 캐릭터"
     store.characters[0].level = 120
+    store.characters[0].additional_stat_groups = [
+        AdditionalStatGroup(
+            name="도감",
+            stats=[
+                AdditionalStatLine(stat_key=StatKey.ATTACK, value=20.0),
+                AdditionalStatLine(stat_key=StatKey.ATTACK, value=30.0),
+            ],
+        )
+    ]
     second_character: CharacterProfile = CharacterStore.create_default().characters[0]
     second_character.name = "두 번째 캐릭터"
     second_character.level = 80
@@ -269,6 +310,15 @@ def test_save_then_load_characters_preserves_state(
         "두 번째 캐릭터",
     ]
     assert [character.level for character in loaded.characters] == [120, 80]
+    assert loaded.characters[0].additional_stat_groups == [
+        AdditionalStatGroup(
+            name="도감",
+            stats=[
+                AdditionalStatLine(stat_key=StatKey.ATTACK, value=20.0),
+                AdditionalStatLine(stat_key=StatKey.ATTACK, value=30.0),
+            ],
+        )
+    ]
     assert os.path.isfile(isolated_data_paths["characters_file_dir"])
 
 


### PR DESCRIPTION
캐릭터별 추가 스탯 그룹을 저장하고 최종 스탯에 반영하도록 추가했습니다.
수치 입력 범위와 기존 데이터 마이그레이션을 정리했습니다.

- 전체 274개 테스트 통과