### PR TITLE
연계스킬 상태 보존 및 실행 불가 입력 차단

### DIFF
--- a/app/scripts/app_state.py
+++ b/app/scripts/app_state.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import IntEnum
 from typing import ClassVar
 
 from app.scripts.calculator_models import CustomPowerFormula
@@ -9,7 +10,6 @@ from app.scripts.config import config
 from app.scripts.macro_models import (
     EquippedSkillRef,
     LinkKeyType,
-    LinkSkill,
     MacroPreset,
     ThemeMode,
 )
@@ -17,6 +17,15 @@ from app.scripts.registry.key_registry import KeyRegistry, KeySpec
 from app.scripts.registry.server_registry import ServerSpec, server_registry
 
 # todo: preset에 종속된 인스턴스들 모두 옮기기
+
+
+class SidebarPage(IntEnum):
+    """사이드바 페이지"""
+
+    GENERAL = 0
+    SKILL = 1
+    LINK_SKILL = 2
+    LINK_SKILL_EDITOR = 3
 
 
 @dataclass
@@ -114,6 +123,9 @@ class MacroState:
     # 잠수 방지 종료 알림 대기 여부
     has_pending_afk_notice: bool = False
 
+    # 실행 불가 연계 단축키 알림 대기 여부
+    has_pending_link_skill_unavailable_notice: bool = False
+
     # 스킬 쿨타임 타이머
     skill_cooltime_timers: dict[EquippedSkillRef, float] = field(default_factory=dict)
 
@@ -154,7 +166,7 @@ class UiState:
     backup_notice_logs: list[str] = field(default_factory=list)
 
     # 현재 활성화된 사이드바 페이지 인덱스
-    current_sidebar_page: int = 0
+    current_sidebar_page: SidebarPage = SidebarPage.GENERAL
 
     # 시작키 설정 중인지
     # todo: SessionState로 이동 고려

--- a/app/scripts/data_manager.py
+++ b/app/scripts/data_manager.py
@@ -13,7 +13,6 @@ from app.scripts.config import config
 from app.scripts.custom_skill_models import CustomSkillImport
 from app.scripts.macro_models import (
     DATA_VERSION,
-    LinkSkill,
     MacroPreset,
     MacroPresetFile,
     MacroPresetRepository,
@@ -943,29 +942,9 @@ def sanitize_preset_registry_references(preset: MacroPreset) -> bool:
         preset.usage_settings.pop(stale_skill_id, None)
         changed = True
 
-    # 존재하지 않는 스킬이 포함된 연계스킬 정리
-    filtered_link_skills: list[LinkSkill] = []
-    link_skill: LinkSkill
-    for link_skill in preset.link_skills:
-        filtered_skill_ids: list[str] = [
-            skill_id for skill_id in link_skill.skills if skill_id in valid_skill_ids
-        ]
-
-        if not filtered_skill_ids:
-            changed = True
-            continue
-
-        if filtered_skill_ids != link_skill.skills:
-            link_skill.skills = filtered_skill_ids
-            link_skill.set_manual()
-            link_skill.clear_key()
-            changed = True
-
-        filtered_link_skills.append(link_skill)
-
-    # 정리된 연계스킬 목록 반영
-    if filtered_link_skills != preset.link_skills:
-        preset.link_skills = filtered_link_skills
+    # 존재하지 않는 스킬 제거 후 최종 배치 기준 자동 연계 상태 정리
+    if preset.reconcile_link_skills(valid_skill_ids).changed:
+        changed = True
 
     return changed
 

--- a/app/scripts/macro_models.py
+++ b/app/scripts/macro_models.py
@@ -379,6 +379,30 @@ class LinkSkill:
         self.remember_state = remember
 
 
+@dataclass(frozen=True)
+class LinkSkillReconcileResult:
+    """연계스킬 정리 결과"""
+
+    # 사용 가능한 스킬이 없어 삭제된 연계 수
+    removed: int = 0
+    # 스킬이 일부 제거되어 구성이 바뀐 연계 수
+    truncated: int = 0
+    # 자동에서 수동으로 전환된 연계 수
+    disabled: int = 0
+
+    @property
+    def has_composition_change(self) -> bool:
+        """연계 삭제 또는 구성 변경 발생 여부"""
+
+        return bool(self.removed or self.truncated)
+
+    @property
+    def changed(self) -> bool:
+        """정리로 인한 변경 발생 여부"""
+
+        return bool(self.removed or self.truncated or self.disabled)
+
+
 @dataclass(slots=True)
 class PresetInfo:
     """프리셋 정보 데이터 모델"""
@@ -485,6 +509,64 @@ class MacroPreset:
             "link_skills": [ls.to_dict() for ls in self.link_skills],
             "info": self.info.to_dict(),
         }
+
+    def reconcile_link_skills(
+        self,
+        allowed_skill_ids: set[str],
+    ) -> LinkSkillReconcileResult:
+        """허용 스킬과 하단 배치의 최종 상태 기준 연계스킬 정리"""
+
+        reconciled_link_skills: list[LinkSkill] = []
+        removed: int = 0
+        truncated: int = 0
+
+        for link_skill in self.link_skills:
+            filtered_skill_ids: list[str] = [
+                skill_id
+                for skill_id in link_skill.skills
+                if skill_id in allowed_skill_ids
+            ]
+
+            # 사용 가능한 스킬이 없는 연계 제거
+            if not filtered_skill_ids:
+                removed += 1
+                continue
+
+            if filtered_skill_ids != link_skill.skills:
+                # 남은 순서와 단축키, 자동 사용 설정은 그대로 유지
+                link_skill.skills = filtered_skill_ids
+                truncated += 1
+
+            reconciled_link_skills.append(link_skill)
+
+        self.link_skills = reconciled_link_skills
+
+        # 절삭 결과까지 반영한 최종 배치 기준으로만 자동 사용 해제 판정
+        disabled: int = self.disable_unrunnable_auto_link_skills()
+
+        return LinkSkillReconcileResult(
+            removed=removed,
+            truncated=truncated,
+            disabled=disabled,
+        )
+
+    def disable_unrunnable_auto_link_skills(self) -> int:
+        """하단 배치되지 않은 자동 연계를 수동으로 전환하고 전환 수 반환"""
+
+        placed_skill_ids: set[str] = set(self.skills.get_placed_skill_ids())
+        disabled: int = 0
+
+        for link_skill in self.link_skills:
+            if link_skill.use_type != LinkUseType.AUTO:
+                continue
+
+            if all(skill_id in placed_skill_ids for skill_id in link_skill.skills):
+                continue
+
+            link_skill.set_manual()
+            disabled += 1
+
+        return disabled
 
     @classmethod
     def create_default(

--- a/app/scripts/run_macro.py
+++ b/app/scripts/run_macro.py
@@ -1145,6 +1145,7 @@ def use_link_skill(session: ManualLinkSession) -> None:
         )
 
         if not all(skill_id in skill_ref_map for skill_id in link_skill.skills):
+            app_state.macro.has_pending_link_skill_unavailable_notice = True
             return
 
         # 쿨타임 동기화 옵션 시 연계스킬 타이머 기준으로 필터링

--- a/app/scripts/ui/guide.py
+++ b/app/scripts/ui/guide.py
@@ -27,7 +27,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from app.scripts.app_state import app_state
+from app.scripts.app_state import SidebarPage, app_state
 from app.scripts.calculator_engine import build_internal_base_stats
 from app.scripts.calculator_models import (
     BaseStats,
@@ -904,7 +904,10 @@ class GuideManager:
             return False
 
         # 사용자가 편집 중인 연계스킬 보호
-        if self.master.sidebar.page_navigator.currentIndex() == 3:
+        if (
+            self.master.sidebar.page_navigator.currentIndex()
+            == SidebarPage.LINK_SKILL_EDITOR
+        ):
             self._show_blocked_dialog(
                 "연계스킬 편집을 마친 뒤 가이드를 시작할 수 있습니다."
             )
@@ -985,25 +988,30 @@ class GuideManager:
         self.master.popup_manager.close_popup()
         self.master.change_layout(0)
 
-    def _sidebar_page(self, index: int) -> None:
+    def _sidebar_page(self, page: SidebarPage) -> None:
         """사이드바 페이지 진입"""
 
         self._main_page()
-        self.master.sidebar.change_page(index)  # type: ignore
+        self.master.sidebar.change_page(page)
 
     def _sidebar_detail_settings(self) -> None:
         """일반 설정의 세부 설정 영역 표시"""
 
-        self._sidebar_page(0)
+        self._sidebar_page(SidebarPage.GENERAL)
         self.master.sidebar.general_settings.show_detail_settings()
 
     def _link_editor_page(self) -> None:
         """임시 연계스킬 편집 페이지 진입"""
 
-        self._sidebar_page(2)
-        if self.master.sidebar.page_navigator.currentIndex() == 3:
+        # 이미 편집 페이지에 있으면 초안을 새로 만들지 않고 현재 편집 상태 유지
+        if (
+            self.master.sidebar.page_navigator.currentIndex()
+            == SidebarPage.LINK_SKILL_EDITOR
+        ):
+            self._main_page()
             return
 
+        self._sidebar_page(SidebarPage.LINK_SKILL)
         self.master.sidebar.link_skill_settings.create_new()
         self._opened_link_editor = True
 
@@ -1016,13 +1024,13 @@ class GuideManager:
         )
         if (
             self.master.page_navigator.currentIndex() == 0
-            and self.master.sidebar.page_navigator.currentIndex() == 1
+            and self.master.sidebar.page_navigator.currentIndex() == SidebarPage.SKILL
             and add_button is not None
         ):
             return
 
         # 무공비급 사용 설정 화면 진입
-        self._sidebar_page(1)
+        self._sidebar_page(SidebarPage.SKILL)
 
         # 선택 무공비급 영역 기준 팝업 표시
         self.master.sidebar.skill_settings.on_scroll_select_clicked()
@@ -1036,7 +1044,7 @@ class GuideManager:
             self._opened_link_editor = False
             return
 
-        self._sidebar_page(2)
+        self._sidebar_page(SidebarPage.LINK_SKILL)
 
     def _ensure_calculator_layout(self) -> None:
         """메인 화면을 계산기로 전환
@@ -1408,37 +1416,37 @@ class GuideManager:
                         "현재 화면 구조 확인",
                         "이 프로그램은 프리셋 단위로 설정을 저장하고 사용합니다. 프리셋마다 서버, 무공비급, 스킬 배치, 계산기 입력이 따로 저장됩니다.",
                         "main.preset_tabs",
-                        lambda: self._sidebar_page(0),
+                        lambda: self._sidebar_page(SidebarPage.GENERAL),
                     ),
                     GuideStep(
                         "서버와 직업 확인",
                         "먼저 현재 프리셋에서 사용할 서버와 직업을 확인합니다.",
                         "sidebar.general.server",
-                        lambda: self._sidebar_page(0),
+                        lambda: self._sidebar_page(SidebarPage.GENERAL),
                     ),
                     GuideStep(
                         "딜레이 확인",
                         "딜레이는 스킬 사이 입력 간격입니다. 너무 낮으면 스킬이 누락될 수 있고, 너무 높으면 사용이 느려집니다.",
                         "sidebar.general.delay",
-                        lambda: self._sidebar_page(0),
+                        lambda: self._sidebar_page(SidebarPage.GENERAL),
                     ),
                     GuideStep(
                         "스킬속도 확인",
                         "캐릭터의 스킬속도(%) 스탯을 입력하면 쿨타임 계산에 반영됩니다.",
                         "sidebar.general.cooltime",
-                        lambda: self._sidebar_page(0),
+                        lambda: self._sidebar_page(SidebarPage.GENERAL),
                     ),
                     GuideStep(
                         "시작키 확인",
                         "짧게 누르면 매크로를 시작하거나 중지합니다. 계속 누르고 있으면 놓을 때까지 매크로를 실행합니다.",
                         "sidebar.general.start_key",
-                        lambda: self._sidebar_page(0),
+                        lambda: self._sidebar_page(SidebarPage.GENERAL),
                     ),
                     GuideStep(
                         "스왑 키 확인",
                         "스왑 키는 1줄과 2줄을 바꿀 때 사용됩니다. 실제 게임 키 설정과 일치해야 합니다.",
                         "sidebar.general.swap_key",
-                        lambda: self._sidebar_page(0),
+                        lambda: self._sidebar_page(SidebarPage.GENERAL),
                     ),
                     GuideStep(
                         "마우스 클릭 설정 확인",
@@ -1510,13 +1518,13 @@ class GuideManager:
                         "커스텀 무공비급 진입 위치",
                         "커스텀 무공비급은 스킬 사용설정의 무공비급 목록에서 추가할 수 있습니다.",
                         "sidebar.skill.selected_scroll",
-                        lambda: self._sidebar_page(1),
+                        lambda: self._sidebar_page(SidebarPage.SKILL),
                     ),
                     GuideStep(
                         "무공비급 선택 팝업 열기",
                         "무공비급 선택 영역을 누르면 현재 서버에서 사용할 수 있는 무공비급 목록이 열립니다.",
                         "sidebar.skill.selected_scroll",
-                        lambda: self._sidebar_page(1),
+                        lambda: self._sidebar_page(SidebarPage.SKILL),
                     ),
                     GuideStep(
                         "새 스킬 추가 위치",
@@ -1534,7 +1542,7 @@ class GuideManager:
                         "마무리",
                         "추가된 무공비급은 기존 무공비급처럼 선택하고 배치할 수 있습니다.",
                         "sidebar.skill.selected_scroll",
-                        lambda: self._sidebar_page(1),
+                        lambda: self._sidebar_page(SidebarPage.SKILL),
                     ),
                 ),
             ),
@@ -1546,13 +1554,13 @@ class GuideManager:
                         "연계스킬 위치 확인",
                         "연계스킬은 여러 스킬을 하나의 스킬처럼 묶어서 사용하는 기능입니다.",
                         "sidebar.nav.link",
-                        lambda: self._sidebar_page(2),
+                        lambda: self._sidebar_page(SidebarPage.LINK_SKILL),
                     ),
                     GuideStep(
                         "새 연계스킬 만들기",
                         "이 버튼을 눌러 새 연계스킬을 만들 수 있습니다.",
                         "sidebar.link.create",
-                        lambda: self._sidebar_page(2),
+                        lambda: self._sidebar_page(SidebarPage.LINK_SKILL),
                     ),
                     GuideStep(
                         "자동 사용",
@@ -1794,37 +1802,37 @@ class GuideManager:
                         "스킬 사용설정 위치",
                         "스킬 사용설정은 장착한 무공비급의 스킬별 동작 방식을 정하는 곳입니다.",
                         "sidebar.nav.skill",
-                        lambda: self._sidebar_page(1),
+                        lambda: self._sidebar_page(SidebarPage.SKILL),
                     ),
                     GuideStep(
                         "설정할 무공비급 선택",
                         "현재 선택한 무공비급의 스킬이 아래 카드에 표시됩니다. 다른 무공비급을 설정하려면 이 영역에서 선택합니다.",
                         "sidebar.skill.selected_scroll",
-                        lambda: self._sidebar_page(1),
+                        lambda: self._sidebar_page(SidebarPage.SKILL),
                     ),
                     GuideStep(
                         "스킬 카드 목록",
                         "선택된 무공비급의 스킬의 설정을 변경할 수 있습니다.",
                         "sidebar.skill.cards",
-                        lambda: self._sidebar_page(1),
+                        lambda: self._sidebar_page(SidebarPage.SKILL),
                     ),
                     GuideStep(
                         "사용 여부",
                         "사용 여부를 끄면 매크로가 해당 스킬을 자동으로 사용하지 않습니다.",
                         "sidebar.skill.usage",
-                        lambda: self._sidebar_page(1),
+                        lambda: self._sidebar_page(SidebarPage.SKILL),
                     ),
                     GuideStep(
                         "단독 사용",
                         "단독 사용은 자동 연계스킬에 포함된 스킬이 다른 스킬들을 기다리지 않고 이 스킬을 우선적으로 사용할지 정하는 설정입니다.",
                         "sidebar.skill.sole",
-                        lambda: self._sidebar_page(1),
+                        lambda: self._sidebar_page(SidebarPage.SKILL),
                     ),
                     GuideStep(
                         "우선순위",
                         "여러 스킬이 동시에 준비되면 우선순위 번호가 낮은 스킬을 먼저 사용합니다.",
                         "sidebar.skill.priority",
-                        lambda: self._sidebar_page(1),
+                        lambda: self._sidebar_page(SidebarPage.SKILL),
                     ),
                     GuideStep(
                         "마무리",

--- a/app/scripts/ui/main_ui/main_ui.py
+++ b/app/scripts/ui/main_ui/main_ui.py
@@ -16,7 +16,7 @@ from PySide6.QtWidgets import (
 )
 
 import app.scripts.run_macro as run_macro
-from app.scripts.app_state import app_state
+from app.scripts.app_state import SidebarPage, app_state
 from app.scripts.custom_classes import CustomFont, SkillImage
 from app.scripts.data_manager import (
     add_preset,
@@ -42,7 +42,11 @@ from app.scripts.ui.popup import (
 from app.scripts.ui.themes import theme_manager
 
 if TYPE_CHECKING:
-    from app.scripts.macro_models import LinkSkill, MacroPreset, SkillUsageSetting
+    from app.scripts.macro_models import (
+        LinkSkillReconcileResult,
+        MacroPreset,
+        SkillUsageSetting,
+    )
     from app.scripts.ui.main_window import MainWindow
     from app.scripts.ui.popup import HoverCardData
 
@@ -83,6 +87,11 @@ class MainUI(QFrame):
 
     def _tick_preview_update(self) -> None:
         """프리뷰 갱신"""
+
+        # 입력 감지 스레드에서 요청한 실행 불가 연계 알림 소비
+        if app_state.macro.has_pending_link_skill_unavailable_notice:
+            app_state.macro.has_pending_link_skill_unavailable_notice = False
+            self.popup_manager.show_notice(NoticeKind.LINK_SKILL_NOT_RUNNABLE)
 
         # 실행 중에는 런타임 상태 기반 프리뷰 주기 갱신
         if app_state.macro.is_running:
@@ -538,7 +547,7 @@ class Tab(QFrame):
     def on_scroll_clicked(self, scroll_index: int) -> None:
         """상단 무공비급 버튼 클릭"""
 
-        if app_state.ui.current_sidebar_page == 4:
+        if app_state.ui.current_sidebar_page == SidebarPage.LINK_SKILL_EDITOR:
             self.noticeRequested.emit(NoticeKind.EDITING_LINK_SKILL)
             return
 
@@ -559,7 +568,7 @@ class Tab(QFrame):
     def on_placed_skill_clicked(self, skill_ref: EquippedSkillRef) -> None:
         """하단 스킬 슬롯 클릭"""
 
-        if app_state.ui.current_sidebar_page == 4:
+        if app_state.ui.current_sidebar_page == SidebarPage.LINK_SKILL_EDITOR:
             self.cancel_skill_selection()
             self.noticeRequested.emit(NoticeKind.EDITING_LINK_SKILL)
             return
@@ -587,15 +596,17 @@ class Tab(QFrame):
             return
 
         # 현재 하단 슬롯에서 제거되는 스킬의 파생 설정 정리
-        self.clear_placed_skill(placed_skill_id)
+        # 연계 상태까지 반영한 뒤 dataChanged로 한 번에 갱신하도록 중간 신호 생략
+        self.clear_placed_skill(placed_skill_id, emit_signal=False)
         self.set_placed_skill(skill_ref, "")
+        self._disable_unrunnable_auto_link_skills()
         self.cancel_skill_selection()
         self.dataChanged.emit()
 
     def on_available_skill_clicked(self, skill_ref: EquippedSkillRef) -> None:
         """상단 제공 스킬 클릭"""
 
-        if app_state.ui.current_sidebar_page == 4:
+        if app_state.ui.current_sidebar_page == SidebarPage.LINK_SKILL_EDITOR:
             self.cancel_skill_selection()
             self.noticeRequested.emit(NoticeKind.EDITING_LINK_SKILL)
             return
@@ -634,9 +645,11 @@ class Tab(QFrame):
         )
         if current_skill_id:
             # 같은 슬롯 재배치 전 기존 스킬의 파생 설정 우선 정리
-            self.clear_placed_skill(current_skill_id)
+            # 연계 상태까지 반영한 뒤 dataChanged로 한 번에 갱신하도록 중간 신호 생략
+            self.clear_placed_skill(current_skill_id, emit_signal=False)
 
         self.set_placed_skill(selected_ref, selected_skill_id)
+        self._disable_unrunnable_auto_link_skills()
         self.cancel_skill_selection()
         self.dataChanged.emit()
 
@@ -674,7 +687,7 @@ class Tab(QFrame):
 
         # 새 장착 결과 반영 및 연계/공유 상태 동기화
         self.preset.skills.equipped_scrolls[scroll_index] = target_scroll_id
-        self._sync_link_skills_to_available_skills()
+        self._reconcile_link_skills()
         self._sync_to_shared_data()
         self.update_from_preset()
 
@@ -684,34 +697,27 @@ class Tab(QFrame):
 
         return True
 
-    def _sync_link_skills_to_available_skills(self) -> None:
-        """현재 무공비급 기준으로 연계스킬 목록 정리"""
+    def _reconcile_link_skills(self) -> None:
+        """현재 무공비급과 하단 배치 기준 연계스킬 상태 정리"""
 
         available_skill_ids: set[str] = set(
             self.preset.skills.get_available_skill_ids(app_state.macro.current_server)
         )
-        filtered_link_skills: list[LinkSkill] = []
+        result: LinkSkillReconcileResult = self.preset.reconcile_link_skills(
+            available_skill_ids
+        )
 
-        # 현재 무공비급이 더 이상 제공하지 않는 스킬은 연계 목록에서 제거
-        for link_skill in self.preset.link_skills:
-            filtered_skill_ids: list[str] = [
-                skill_id
-                for skill_id in link_skill.skills
-                if skill_id in available_skill_ids
-            ]
+        if result.has_composition_change:
+            self.noticeRequested.emit(NoticeKind.LINK_SKILL_ADJUSTED)
 
-            if not filtered_skill_ids:
-                continue
+        if result.disabled:
+            self.noticeRequested.emit(NoticeKind.LINK_SKILL_AUTO_DISABLED)
 
-            if filtered_skill_ids != link_skill.skills:
-                # 스킬 구성 변경 시 자동 연계와 단축키 설정 초기화
-                link_skill.skills = filtered_skill_ids
-                link_skill.set_manual()
-                link_skill.clear_key()
+    def _disable_unrunnable_auto_link_skills(self) -> None:
+        """배치 변경으로 실행 불가해진 자동 연계 해제 및 알림 요청"""
 
-            filtered_link_skills.append(link_skill)
-
-        self.preset.link_skills = filtered_link_skills
+        if self.preset.disable_unrunnable_auto_link_skills():
+            self.noticeRequested.emit(NoticeKind.LINK_SKILL_AUTO_DISABLED)
 
     def clear_skill_if_placed(
         self,
@@ -736,12 +742,6 @@ class Tab(QFrame):
 
     def clear_placed_skill(self, skill_id: str, emit_signal: bool = True) -> None:
         """배치 해제 파생 설정 정리"""
-
-        # 연계에 포함된 스킬의 수동 설정 복원
-        for link in self.preset.link_skills:
-            if skill_id in link.skills:
-                link.set_manual()
-                link.clear_key()
 
         # 우선순위 제거 및 뒤 번호 당기기
         setting: SkillUsageSetting = self.preset.usage_settings[skill_id]

--- a/app/scripts/ui/main_ui/sidebar.py
+++ b/app/scripts/ui/main_ui/sidebar.py
@@ -24,7 +24,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from app.scripts.app_state import app_state
+from app.scripts.app_state import SidebarPage, app_state
 from app.scripts.config import config
 from app.scripts.custom_classes import CustomFont, SkillImage
 from app.scripts.custom_skill_models import CustomScrollDefinition, CustomSkillImport
@@ -253,9 +253,7 @@ class Sidebar(QFrame):
         self.page_navigator.setFixedWidth(300)
 
         # 초기 페이지 설정
-        self.page_navigator.setCurrentIndex(0)
-        self.nav_button.set_active_button(0)
-        self.adjust_stack_height()
+        self.change_page(SidebarPage.GENERAL)
 
         # 무공비급바
         self.scroll_area: QScrollArea = QScrollArea()
@@ -289,14 +287,14 @@ class Sidebar(QFrame):
         """연계스킬 편집 요청 처리: 편집기 로드 후 편집 페이지로 이동."""
 
         self.link_skill_editor.load(data, int(index))
-        self.change_page(3)
+        self.change_page(SidebarPage.LINK_SKILL_EDITOR)
 
     def _on_link_skill_editor_closed(self) -> None:
         """연계스킬 편집 페이지 종료(취소/저장 이후) 시 목록 페이지로 복귀."""
 
         # 목록 UI를 최신 상태로 갱신
         self.link_skill_settings.update_from_preset(self.preset)
-        self.change_page(2)
+        self.change_page(SidebarPage.LINK_SKILL)
 
     def _on_link_skill_editor_saved(self) -> None:
         """연계스킬 저장 완료 후 사이드바 전체 갱신."""
@@ -311,12 +309,12 @@ class Sidebar(QFrame):
         self.preset = preset
         self.preset_index = int(preset_index)
 
-        if self.page_navigator.currentIndex() == 3:
+        if self.page_navigator.currentIndex() == SidebarPage.LINK_SKILL_EDITOR:
             self.link_skill_editor.cancel()
 
         self.update_from_preset()
 
-        self.change_page(0)
+        self.change_page(SidebarPage.GENERAL)
 
     def update_from_preset(self) -> None:
         """프리셋을 사이드바 페이지들에 적용"""
@@ -344,15 +342,16 @@ class Sidebar(QFrame):
 
         self.adjust_stack_height()
 
-    def change_page(self, index: Literal[0, 1, 2, 3]) -> None:
+    def change_page(self, page: SidebarPage) -> None:
         """페이지 변경"""
 
-        self.page_navigator.setCurrentIndex(index)
+        self.page_navigator.setCurrentIndex(page)
+        app_state.ui.current_sidebar_page = page
 
-        # 인덱스 3은 연계스킬 편집 페이지,
-        # 버튼 3은 계산기 페이지이므로 활성화하지 않음
-        if index != 3:
-            self.nav_button.set_active_button(index)
+        # 연계스킬 편집 페이지는 대응하는 네비게이션 버튼이 없음
+        # (같은 자리의 버튼은 계산기 전환용이므로 활성화하지 않음)
+        if page != SidebarPage.LINK_SKILL_EDITOR:
+            self.nav_button.set_active_button(page)
 
         self.adjust_stack_height()
 
@@ -1905,8 +1904,14 @@ class SkillSettings(QFrame):
 
         remove_custom_scroll(server_spec.id, scroll_id)
 
-        # 모든 프리셋에서 삭제된 무공비급/스킬 관련 데이터 정리
+        # 삭제가 반영된 레지스트리 기준 유효 스킬 목록
+        valid_skill_ids: set[str] = set(server_spec.skill_registry.get_all_skill_ids())
+
+        # 같은 서버의 모든 프리셋에서 삭제된 무공비급/스킬 관련 데이터 정리
         for preset in app_state.macro.presets:
+            if preset.settings.server_id != server_spec.id:
+                continue
+
             # 장착 무공비급 슬롯에서 제거
             for i, sid in enumerate(preset.skills.equipped_scrolls):
                 if sid == scroll_id:
@@ -1924,12 +1929,8 @@ class SkillSettings(QFrame):
             # 무공비급 레벨 저장값 제거
             preset.info.scroll_levels.pop(scroll_id, None)
 
-            # 해당 스킬을 포함하는 연계스킬 제거
-            preset.link_skills = [
-                ls
-                for ls in preset.link_skills
-                if not deleted_skill_ids.intersection(ls.skills)
-            ]
+            # 삭제된 스킬만 제외하고 남은 연계 순서와 단축키 유지
+            preset.reconcile_link_skills(valid_skill_ids)
 
         self._selected_scroll_id = ""
         self.update_from_preset(self._get_preset())
@@ -2772,6 +2773,10 @@ class LinkSkillEditor(QFrame):
             preset.link_skills[index] = self.data
             self._editing_index = index
 
+        # 저장 시점의 하단 배치 기준 자동 연계 상태 보정
+        if preset.disable_unrunnable_auto_link_skills():
+            self.popup_manager.show_notice(NoticeKind.LINK_SKILL_AUTO_DISABLED)
+
         self._on_data_changed()
 
         self.saved.emit()
@@ -2971,16 +2976,19 @@ class LinkSkillEditor(QFrame):
 
 
 class NavigationButtons(QFrame):
+    # 사이드바 페이지가 아닌 계산기 화면으로 이동하는 버튼 위치
+    _CALCULATOR_BUTTON_INDEX: int = 3
+
     def __init__(
         self,
-        change_page: Callable[[Literal[0, 1, 2, 3]], None],
+        change_page: Callable[[SidebarPage], None],
         change_layout: Callable[[int], None],
         guide_requested: Callable[[], None],
     ) -> None:
         super().__init__()
 
         self.setObjectName("navButtonsFrame")
-        self.change_page: Callable[[Literal[0, 1, 2, 3]], None] = change_page
+        self.change_page: Callable[[SidebarPage], None] = change_page
         self.change_layout: Callable[[int], None] = change_layout
         self.guide_requested: Callable[[], None] = guide_requested
 
@@ -3011,8 +3019,11 @@ class NavigationButtons(QFrame):
         for idx, button in enumerate(self.buttons):
             layout.addWidget(button)
 
-            if idx != 3:
-                button.clicked.connect(partial(lambda x: self.change_page(x), idx))
+            # 마지막 버튼만 사이드바 페이지가 아닌 계산기 화면 전환용
+            if idx != self._CALCULATOR_BUTTON_INDEX:
+                button.clicked.connect(
+                    partial(lambda page: self.change_page(page), SidebarPage(idx))
+                )
             else:
                 button.clicked.connect(lambda: self.change_layout(1))
 

--- a/app/scripts/ui/popup.py
+++ b/app/scripts/ui/popup.py
@@ -135,6 +135,9 @@ class NoticeKind(Enum):
     MACRO_IS_RUNNING = auto()  # 매크로 작동중
     EDITING_LINK_SKILL = auto()  # 연계스킬 수정중
     AFK_STOPPED = auto()  # 잠수 방지 종료
+    LINK_SKILL_NOT_RUNNABLE = auto()  # 연계스킬 실행 불가
+    LINK_SKILL_ADJUSTED = auto()  # 연계스킬 구성 정리
+    LINK_SKILL_AUTO_DISABLED = auto()  # 연계스킬 자동 사용 해제
 
     # 스킬 관련
     SKILL_NOT_SELECTED = auto()  # 스킬 미선택
@@ -961,7 +964,7 @@ class NoticeController:
 
             case NoticeKind.EDITING_LINK_SKILL:
                 return NoticeData(
-                    "연계스킬을 수정중이기 때문에 장착스킬을 변경할 수 없습니다."
+                    "연계스킬을 수정 중이기 때문에 장착 스킬과 무공비급을 변경할 수 없습니다."
                 )
 
             case NoticeKind.AFK_STOPPED:
@@ -970,9 +973,26 @@ class NoticeController:
                     "warning",
                 )
 
+            case NoticeKind.LINK_SKILL_NOT_RUNNABLE:
+                return NoticeData(
+                    "연계스킬에 배치되지 않은 스킬이 있어 실행할 수 없습니다."
+                )
+
+            case NoticeKind.LINK_SKILL_ADJUSTED:
+                return NoticeData(
+                    "장착 무공비급이 바뀌어 일부 연계스킬을 정리했습니다.",
+                    "warning",
+                )
+
+            case NoticeKind.LINK_SKILL_AUTO_DISABLED:
+                return NoticeData(
+                    "실행할 수 없는 연계스킬의 자동 사용을 껐습니다.",
+                    "warning",
+                )
+
             case NoticeKind.SKILL_NOT_SELECTED:
                 return NoticeData(
-                    "해당 연계스킬에 장착중이지 않은 스킬이 포함되어있습니다."
+                    "배치되지 않은 스킬이 있어 자동 사용을 켤 수 없습니다."
                 )
 
             case NoticeKind.AUTO_ALREADY_EXIST:

--- a/tests/test_app_smoke.py
+++ b/tests/test_app_smoke.py
@@ -16,10 +16,12 @@ from PySide6.QtWidgets import QApplication, QTabBar
 import app.scripts
 import app.scripts.run_macro as run_macro
 from app.scripts import data_manager
-from app.scripts.app_state import app_state
+from app.scripts.app_state import SidebarPage, app_state
 from app.scripts.config import config
+from app.scripts.macro_models import LinkSkill, LinkUseType
 from app.scripts.ui.popup import (
     InputConfirmContent,
+    NoticeKind,
     PopupAction,
     PopupKind,
     PopupPlacement,
@@ -118,6 +120,63 @@ def test_main_window_and_lazy_pages_construct_offscreen(
     assert simulator.results_page is results_page
     assert simulator.character_page is character_page
 
+    # 연계 편집 중 스킬·무공비급 변경 차단과 저장 시 자동 상태 보정
+    preset = app_state.macro.current_preset
+    current_tab = window.main_ui.tab_widget.get_current_tab()
+    server = app_state.macro.current_server
+    scroll_id: str = server.skill_registry.get_all_scroll_ids()[0]
+    skill_id: str = server.skill_registry.get_scroll(scroll_id).skills[0]
+    preset.skills.equipped_scrolls[0] = scroll_id
+    preset.skills.placed_skills[0] = skill_id
+    preset.link_skills = [LinkSkill(use_type=LinkUseType.AUTO, skills=[skill_id])]
+    current_tab.update_from_preset()
+    window.sidebar.update_from_preset()
+
+    popup_manager = window.get_popup_manager()
+    editing_notices: list[NoticeKind] = []
+    current_tab.noticeRequested.connect(editing_notices.append)
+    monkeypatch.setattr(
+        popup_manager._notice_controller,
+        "show",
+        lambda _kind, _text=None: None,
+    )
+
+    window.show()
+    qapplication.processEvents()
+    window.sidebar.link_skill_settings.edit(0)
+    assert app_state.ui.current_sidebar_page == SidebarPage.LINK_SKILL_EDITOR
+
+    QTest.mouseClick(
+        current_tab.placed_skills.columns[0].buttons[0],
+        Qt.MouseButton.LeftButton,
+    )
+    QTest.mouseClick(
+        current_tab.available_skills.columns[0].skill_buttons[0],
+        Qt.MouseButton.LeftButton,
+    )
+    QTest.mouseClick(
+        current_tab.available_skills.get_scroll_button(0),
+        Qt.MouseButton.LeftButton,
+    )
+    QTest.mouseClick(
+        current_tab.available_skills.get_scroll_button(1),
+        Qt.MouseButton.LeftButton,
+    )
+    qapplication.processEvents()
+
+    assert preset.skills.placed_skills[0] == skill_id
+    assert preset.skills.equipped_scrolls[0] == scroll_id
+    assert preset.skills.equipped_scrolls[1] == ""
+    assert current_tab.get_selected_skill_ref() is None
+    assert not popup_manager.is_popup_active(PopupKind.SCROLL_SELECT)
+    assert editing_notices == [NoticeKind.EDITING_LINK_SKILL] * 4
+
+    # 편집 외부에서 배치 상태가 달라져도 실행 불가능한 AUTO 저장 방지
+    preset.skills.placed_skills[0] = ""
+    window.sidebar.link_skill_editor.save()
+    assert preset.link_skills[0].use_type == LinkUseType.MANUAL
+    assert app_state.ui.current_sidebar_page == SidebarPage.LINK_SKILL
+
     # 수동 연계 입력 중 프리셋 전환 차단 확인
     data_manager.add_preset()
     window.main_ui.tab_widget.add_tab(app_state.macro.presets[-1])
@@ -196,6 +255,18 @@ def test_main_window_and_lazy_pages_construct_offscreen(
     qapplication.processEvents()
     assert window.main_ui.tab_widget.currentIndex() == 1
     assert app_state.macro.current_preset_index == 1
+
+    # 입력 감지 스레드의 실행 불가 연계 알림을 UI 스레드에서 1회 소비
+    shown_notices: list[NoticeKind] = []
+    monkeypatch.setattr(
+        popup_manager,
+        "show_notice",
+        lambda kind, _text=None: shown_notices.append(kind),
+    )
+    app_state.macro.has_pending_link_skill_unavailable_notice = True
+    window.main_ui._tick_preview_update()
+    assert shown_notices == [NoticeKind.LINK_SKILL_NOT_RUNNABLE]
+    assert app_state.macro.has_pending_link_skill_unavailable_notice is False
 
     window.hide()
     window.deleteLater()

--- a/tests/test_link_skill_reconcile_ui.py
+++ b/tests/test_link_skill_reconcile_ui.py
@@ -1,0 +1,340 @@
+from __future__ import annotations
+
+import os
+
+# 장착 구성 변경 UI 검증의 디스플레이 비의존 실행 보장
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from collections.abc import Iterator
+
+import pytest
+from PySide6.QtCore import Qt
+from PySide6.QtTest import QTest
+from PySide6.QtWidgets import QApplication, QLabel
+
+from app.scripts import data_manager
+from app.scripts.app_state import SidebarPage, app_state
+from app.scripts.custom_skill_models import CustomSkillImport
+from app.scripts.macro_models import (
+    LinkKeyType,
+    LinkSkill,
+    LinkUseType,
+    MacroPreset,
+    SkillUsageSetting,
+)
+from app.scripts.ui.main_ui.main_ui import Tab
+from app.scripts.ui.main_window import MainWindow
+from app.scripts.ui.popup import NoticeKind
+
+
+@pytest.fixture(scope="session")
+def qapplication() -> Iterator[QApplication]:
+    """Qt 위젯 생성 테스트가 공유하는 단일 QApplication"""
+
+    application = QApplication.instance()
+    owns_application: bool = application is None
+    if application is None:
+        application = QApplication([])
+
+    assert isinstance(application, QApplication)
+    application.setQuitOnLastWindowClosed(False)
+    yield application
+
+    if owns_application:
+        application.quit()
+
+
+@pytest.fixture
+def main_window(
+    qapplication: QApplication,
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_data_paths: dict[str, str],
+) -> Iterator[MainWindow]:
+    """백그라운드 작업과 시작 프롬프트를 제외한 메인 창"""
+
+    monkeypatch.setattr(MainWindow, "activate_thread", lambda self: None)
+    monkeypatch.setattr(MainWindow, "_run_startup_prompts", lambda self: None)
+    monkeypatch.setattr(MainWindow, "_restore_window_geometry", lambda self: None)
+    monkeypatch.setattr(MainWindow, "_confirm_future_data_execution", lambda self: True)
+
+    window: MainWindow = MainWindow()
+    window.show()
+    qapplication.processEvents()
+
+    yield window
+
+    window.hide()
+    window.deleteLater()
+    qapplication.processEvents()
+
+
+def _auto_badges(window: MainWindow) -> list[str]:
+    """사이드바 연계 목록에 표시된 자동 사용 배지 문구 수집"""
+
+    layout = window.sidebar.link_skill_settings._list_layout
+    badge_texts: list[str] = []
+
+    for index in range(layout.count()):
+        item = layout.itemAt(index)
+        widget = None if item is None else item.widget()
+        if widget is None:
+            continue
+
+        label: QLabel
+        for label in widget.findChildren(QLabel):
+            if label.objectName() in ("badgeAuto", "badgeManual"):
+                badge_texts.append(label.text())
+
+    return badge_texts
+
+
+def test_unplacing_skill_disables_auto_and_notifies(
+    qapplication: QApplication,
+    main_window: MainWindow,
+) -> None:
+    """배치 해제 시 순서·단축키 유지, 자동 해제 알림, 목록 갱신 검증"""
+
+    preset: MacroPreset = app_state.macro.current_preset
+    tab: Tab = main_window.main_ui.tab_widget.get_current_tab()
+    registry = app_state.macro.current_server.skill_registry
+    scroll_ids: list[str] = registry.get_all_scroll_ids()
+    first_skill_id: str = registry.get_scroll(scroll_ids[0]).skills[0]
+    second_skill_id: str = registry.get_scroll(scroll_ids[1]).skills[0]
+
+    preset.skills.equipped_scrolls[0] = scroll_ids[0]
+    preset.skills.equipped_scrolls[1] = scroll_ids[1]
+    preset.skills.placed_skills[0] = first_skill_id
+    preset.skills.placed_skills[1] = second_skill_id
+    preset.link_skills = [
+        LinkSkill(
+            use_type=LinkUseType.AUTO,
+            key_type=LinkKeyType.ON,
+            key="q",
+            skills=[second_skill_id, first_skill_id],
+        )
+    ]
+    tab.update_from_preset()
+    main_window.sidebar.update_from_preset()
+    main_window.sidebar.change_page(SidebarPage.LINK_SKILL)
+    qapplication.processEvents()
+
+    notices: list[NoticeKind] = []
+    tab.noticeRequested.connect(notices.append)
+
+    # 선택 후 재클릭으로 첫 슬롯 배치 해제
+    slot_button = tab.placed_skills.columns[0].buttons[0]
+    QTest.mouseClick(slot_button, Qt.MouseButton.LeftButton)
+    QTest.mouseClick(slot_button, Qt.MouseButton.LeftButton)
+    qapplication.processEvents()
+
+    link_skill: LinkSkill = preset.link_skills[0]
+    assert preset.skills.placed_skills[0] == ""
+    assert notices == [NoticeKind.LINK_SKILL_AUTO_DISABLED]
+    assert link_skill.skills == [second_skill_id, first_skill_id]
+    assert link_skill.use_type == LinkUseType.MANUAL
+    assert link_skill.key_type == LinkKeyType.ON
+    assert link_skill.key == "q"
+    assert _auto_badges(main_window) == ["자동 OFF"]
+
+
+def test_unequipping_scroll_reconciles_link_skills_and_notifies(
+    qapplication: QApplication,
+    main_window: MainWindow,
+) -> None:
+    """무공비급 해제 시 연계 삭제·구성 정리와 실행 가능한 자동 연계 유지 검증"""
+
+    preset: MacroPreset = app_state.macro.current_preset
+    tab: Tab = main_window.main_ui.tab_widget.get_current_tab()
+    registry = app_state.macro.current_server.skill_registry
+    scroll_ids: list[str] = registry.get_all_scroll_ids()
+    removed_skill_id: str = registry.get_scroll(scroll_ids[0]).skills[0]
+    kept_skill_id: str = registry.get_scroll(scroll_ids[1]).skills[0]
+    unrelated_skill_id: str = registry.get_scroll(scroll_ids[2]).skills[0]
+
+    preset.skills.equipped_scrolls[0] = scroll_ids[0]
+    preset.skills.equipped_scrolls[1] = scroll_ids[1]
+    preset.skills.equipped_scrolls[2] = scroll_ids[2]
+    preset.skills.placed_skills[0] = removed_skill_id
+    preset.skills.placed_skills[1] = kept_skill_id
+    preset.skills.placed_skills[2] = unrelated_skill_id
+    preset.link_skills = [
+        # 해제 대상 스킬이 빠져 구성만 바뀌는 연계
+        LinkSkill(
+            use_type=LinkUseType.AUTO,
+            key_type=LinkKeyType.ON,
+            key="q",
+            skills=[kept_skill_id, removed_skill_id],
+        ),
+        # 남는 스킬이 없어 통째로 사라지는 연계
+        LinkSkill(
+            use_type=LinkUseType.MANUAL,
+            key_type=LinkKeyType.ON,
+            key="e",
+            skills=[removed_skill_id],
+        ),
+        # 해제 영향을 받지 않는 자동 연계
+        LinkSkill(use_type=LinkUseType.AUTO, skills=[unrelated_skill_id]),
+    ]
+    tab.update_from_preset()
+    main_window.sidebar.update_from_preset()
+    main_window.sidebar.change_page(SidebarPage.LINK_SKILL)
+    qapplication.processEvents()
+
+    notices: list[NoticeKind] = []
+    tab.noticeRequested.connect(notices.append)
+
+    # 장착된 무공비급 슬롯 재클릭으로 장착 해제
+    QTest.mouseClick(
+        tab.available_skills.get_scroll_button(0),
+        Qt.MouseButton.LeftButton,
+    )
+    qapplication.processEvents()
+
+    assert preset.skills.equipped_scrolls[0] == ""
+    assert notices == [NoticeKind.LINK_SKILL_ADJUSTED]
+
+    # 구성이 바뀌어도 남은 스킬이 모두 배치되어 있으면 순서·단축키·자동 사용 유지
+    adjusted_link: LinkSkill = preset.link_skills[0]
+    assert adjusted_link.skills == [kept_skill_id]
+    assert adjusted_link.use_type == LinkUseType.AUTO
+    assert adjusted_link.key_type == LinkKeyType.ON
+    assert adjusted_link.key == "q"
+
+    # 영향을 받지 않은 연계는 자동 유지
+    assert len(preset.link_skills) == 2
+    assert preset.link_skills[1].use_type == LinkUseType.AUTO
+    assert _auto_badges(main_window) == ["자동 ON", "자동 ON"]
+
+
+def test_deleting_custom_scroll_preserves_remaining_link_skill(
+    main_window: MainWindow,
+) -> None:
+    """커스텀 비급 삭제 시 남은 연계 보존과 실행 가능성별 자동 상태 검증"""
+
+    server = app_state.macro.current_server
+    registry = server.skill_registry
+    custom_scroll_id: str = f"custom:{server.id}:연계삭제테스트비급"
+    custom_skill_a_id: str = f"custom:{server.id}:연계삭제테스트A"
+    custom_skill_b_id: str = f"custom:{server.id}:연계삭제테스트B"
+    custom_import: CustomSkillImport = CustomSkillImport.from_dict(
+        {
+            "skills": [custom_skill_a_id, custom_skill_b_id],
+            "scrolls": [
+                {
+                    "scroll_id": custom_scroll_id,
+                    "name": "연계삭제테스트비급",
+                    "skills": [custom_skill_a_id, custom_skill_b_id],
+                }
+            ],
+            "skill_details": {
+                custom_skill_a_id: {
+                    "name": "연계삭제테스트A",
+                    "cooltime": 4.0,
+                    "target_count": 1,
+                    "levels": {"1": 1.0},
+                },
+                custom_skill_b_id: {
+                    "name": "연계삭제테스트B",
+                    "cooltime": 5.0,
+                    "target_count": 1,
+                    "levels": {"1": 1.0},
+                },
+            },
+        }
+    )
+    data_manager.save_custom_skills(server.id, custom_import)
+    data_manager.load_custom_skills()
+
+    builtin_scroll_id: str = next(
+        scroll_id
+        for scroll_id in registry.get_all_scroll_ids()
+        if scroll_id != custom_scroll_id
+    )
+    builtin_skill_id: str = registry.get_scroll(builtin_scroll_id).skills[0]
+    unplaced_builtin_skill_id: str = registry.get_scroll(builtin_scroll_id).skills[1]
+    preset: MacroPreset = app_state.macro.current_preset
+    preset.skills.equipped_scrolls[0] = custom_scroll_id
+    preset.skills.equipped_scrolls[1] = builtin_scroll_id
+    preset.skills.placed_skills[0] = custom_skill_a_id
+    preset.skills.placed_skills[1] = builtin_skill_id
+    preset.usage_settings[custom_skill_a_id] = SkillUsageSetting()
+    preset.usage_settings[custom_skill_b_id] = SkillUsageSetting()
+    preset.info.scroll_levels[custom_scroll_id] = 1
+    preset.link_skills = [
+        LinkSkill(
+            use_type=LinkUseType.AUTO,
+            key_type=LinkKeyType.ON,
+            key="q",
+            skills=[custom_skill_a_id, builtin_skill_id],
+        ),
+        LinkSkill(
+            use_type=LinkUseType.AUTO,
+            key_type=LinkKeyType.ON,
+            key="e",
+            skills=[custom_skill_b_id, unplaced_builtin_skill_id],
+        ),
+        LinkSkill(
+            use_type=LinkUseType.MANUAL,
+            key_type=LinkKeyType.ON,
+            key="r",
+            skills=[custom_skill_b_id],
+        ),
+    ]
+
+    main_window.sidebar.skill_settings._selected_scroll_id = custom_scroll_id
+    main_window.sidebar.skill_settings._on_delete_custom_scroll()
+
+    assert custom_scroll_id not in registry.get_all_scroll_ids()
+    assert custom_skill_a_id not in registry.get_all_skill_ids()
+    assert custom_skill_b_id not in registry.get_all_skill_ids()
+    assert custom_scroll_id not in preset.skills.equipped_scrolls
+    assert custom_skill_a_id not in preset.skills.placed_skills
+    assert custom_skill_a_id not in preset.usage_settings
+    assert custom_skill_b_id not in preset.usage_settings
+    assert custom_scroll_id not in preset.info.scroll_levels
+
+    assert len(preset.link_skills) == 2
+
+    runnable_link: LinkSkill = preset.link_skills[0]
+    assert runnable_link.skills == [builtin_skill_id]
+    assert runnable_link.use_type == LinkUseType.AUTO
+    assert runnable_link.key_type == LinkKeyType.ON
+    assert runnable_link.key == "q"
+
+    unrunnable_link: LinkSkill = preset.link_skills[1]
+    assert unrunnable_link.skills == [unplaced_builtin_skill_id]
+    assert unrunnable_link.use_type == LinkUseType.MANUAL
+    assert unrunnable_link.key_type == LinkKeyType.ON
+    assert unrunnable_link.key == "e"
+
+
+def test_sidebar_page_state_tracks_navigation(
+    qapplication: QApplication,
+    main_window: MainWindow,
+) -> None:
+    """연계 편집 중 변경 차단이 의존하는 사이드바 페이지 상태 동기화 검증"""
+
+    # 네비게이션 버튼 경로
+    QTest.mouseClick(
+        main_window.sidebar.nav_button.buttons[SidebarPage.SKILL],
+        Qt.MouseButton.LeftButton,
+    )
+    qapplication.processEvents()
+    assert app_state.ui.current_sidebar_page == SidebarPage.SKILL
+
+    # 가이드 경로
+    main_window.guide_manager._sidebar_page(SidebarPage.LINK_SKILL)
+    assert (
+        main_window.sidebar.page_navigator.currentIndex() == SidebarPage.LINK_SKILL
+    )
+    assert app_state.ui.current_sidebar_page == SidebarPage.LINK_SKILL
+
+    # 연계스킬 편집 진입 및 복귀
+    registry = app_state.macro.current_server.skill_registry
+    skill_id: str = registry.get_scroll(registry.get_all_scroll_ids()[0]).skills[0]
+    app_state.macro.current_preset.link_skills = [LinkSkill(skills=[skill_id])]
+    main_window.sidebar.link_skill_settings.edit(0)
+    assert app_state.ui.current_sidebar_page == SidebarPage.LINK_SKILL_EDITOR
+
+    main_window.sidebar.link_skill_editor.cancel()
+    assert app_state.ui.current_sidebar_page == SidebarPage.LINK_SKILL

--- a/tests/test_macro_runtime.py
+++ b/tests/test_macro_runtime.py
@@ -545,6 +545,50 @@ def test_checking_thread_preserves_press_time_when_release_races_with_activation
     assert session.trigger_pressed_at == 99.0
 
 
+def test_unavailable_manual_link_requests_notice_without_skill_input(
+    macro_state_with_preset: MacroPreset,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """미배치 스킬 연계 단축키의 입력 차단과 알림 요청 검증"""
+
+    trigger_key: KeySpec = KeyRegistry.get("q")
+    unplaced_skill_id: str = macro_state_with_preset.skills.placed_skills[0]
+    macro_state_with_preset.skills.placed_skills[0] = ""
+    link_skill = LinkSkill(
+        key_type=LinkKeyType.ON,
+        key=trigger_key.key_id,
+        skills=[unplaced_skill_id],
+    )
+    session = run_macro.ManualLinkSession(
+        link_skill=link_skill,
+        trigger_key=trigger_key,
+        trigger_pressed_at=99.0,
+        delay_seconds=0.3,
+        hold_transition_at=99.3,
+    )
+
+    monkeypatch.setattr(run_macro.keyboard, "Controller", lambda: None)
+    monkeypatch.setattr(run_macro.mouse, "Controller", lambda: None)
+    monkeypatch.setattr(
+        run_macro,
+        "_run_manual_link_cycle",
+        lambda *_args, **_kwargs: pytest.fail("실행 불가 연계가 입력을 시도함"),
+    )
+    monkeypatch.setattr(run_macro, "is_input_sequence_running", True)
+    monkeypatch.setattr(run_macro, "active_manual_link_session", session)
+    monkeypatch.setattr(
+        app_state.macro,
+        "has_pending_link_skill_unavailable_notice",
+        False,
+    )
+
+    run_macro.use_link_skill(session)
+
+    assert run_macro.active_manual_link_session is None
+    assert run_macro.is_input_sequence_running is False
+    assert app_state.macro.has_pending_link_skill_unavailable_notice is True
+
+
 def _record_manual_link_run(
     monkeypatch: pytest.MonkeyPatch,
     link_skill: LinkSkill,

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -548,20 +548,30 @@ def test_sanitize_removes_stale_registry_references(
 ) -> None:
     stale_scroll_id: str = "custom:test_server:삭제된비급"
     stale_skill_id: str = "custom:test_server:삭제된스킬"
-    valid_skill_id: str = full_preset.skills.placed_skills[2]
+    first_valid_skill_id: str = full_preset.skills.placed_skills[2]
+    second_valid_skill_id: str = full_preset.skills.placed_skills[4]
+    unplaced_skill_id: str = full_preset.skills.placed_skills[6]
     full_preset.skills.equipped_scrolls[0] = stale_scroll_id
     full_preset.skills.placed_skills[0] = stale_skill_id
+    full_preset.skills.placed_skills[6] = ""
     full_preset.info.scroll_levels[stale_scroll_id] = 9
     full_preset.usage_settings[stale_skill_id] = SkillUsageSetting(priority=2)
     partially_valid_link: LinkSkill = LinkSkill(
         use_type=LinkUseType.AUTO,
         key_type=LinkKeyType.ON,
         key="q",
-        skills=[valid_skill_id, stale_skill_id],
+        skills=[first_valid_skill_id, stale_skill_id, second_valid_skill_id],
         remember_state=True,
+    )
+    unplaced_link: LinkSkill = LinkSkill(
+        use_type=LinkUseType.AUTO,
+        key_type=LinkKeyType.ON,
+        key="e",
+        skills=[unplaced_skill_id],
     )
     full_preset.link_skills = [
         partially_valid_link,
+        unplaced_link,
         LinkSkill(skills=[stale_skill_id]),
     ]
 
@@ -570,11 +580,42 @@ def test_sanitize_removes_stale_registry_references(
     assert full_preset.skills.placed_skills[0] == ""
     assert stale_scroll_id not in full_preset.info.scroll_levels
     assert stale_skill_id not in full_preset.usage_settings
-    assert full_preset.link_skills == [partially_valid_link]
-    assert partially_valid_link.skills == [valid_skill_id]
-    assert partially_valid_link.use_type == LinkUseType.MANUAL
-    assert partially_valid_link.key is None
+    assert full_preset.link_skills == [partially_valid_link, unplaced_link]
+    assert partially_valid_link.skills == [
+        first_valid_skill_id,
+        second_valid_skill_id,
+    ]
+    # 구성이 바뀌어도 남은 스킬이 모두 배치되어 있으면 자동 사용까지 유지
+    assert partially_valid_link.use_type == LinkUseType.AUTO
+    assert partially_valid_link.key_type == LinkKeyType.ON
+    assert partially_valid_link.key == "q"
     assert partially_valid_link.remember_state is True
+    # 남은 스킬이 배치되어 있지 않은 연계만 자동 사용 해제
+    assert unplaced_link.skills == [unplaced_skill_id]
+    assert unplaced_link.use_type == LinkUseType.MANUAL
+    assert unplaced_link.key_type == LinkKeyType.ON
+    assert unplaced_link.key == "e"
+
+
+def test_unplaced_link_skill_preserves_sequence_and_shortcut(
+    full_preset: MacroPreset,
+) -> None:
+    first_skill_id: str = full_preset.skills.placed_skills[1]
+    second_skill_id: str = full_preset.skills.placed_skills[8]
+    link_skill: LinkSkill = LinkSkill(
+        use_type=LinkUseType.AUTO,
+        key_type=LinkKeyType.ON,
+        key="q",
+        skills=[first_skill_id, second_skill_id],
+    )
+    full_preset.link_skills = [link_skill]
+    full_preset.skills.placed_skills[8] = ""
+
+    assert full_preset.disable_unrunnable_auto_link_skills() == 1
+    assert link_skill.skills == [first_skill_id, second_skill_id]
+    assert link_skill.use_type == LinkUseType.MANUAL
+    assert link_skill.key_type == LinkKeyType.ON
+    assert link_skill.key == "q"
 
 
 def test_sanitize_leaves_valid_preset_unchanged(


### PR DESCRIPTION
장착 구성 변경 시 연계스킬의 순서와 단축키를 유지하고, 실행할 수 없는 연계는 안전하게 전환하거나 입력을 차단하도록 개선했습니다.

- 전체 280개 테스트 통과